### PR TITLE
[Feature] Authentication, apiClient(fetch wrapper), SessionProvider 구현

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["NEXTAUTH"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.475.0",
         "next": "15.1.7",
+        "next-auth": "^5.0.0-beta.25",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -40,6 +41,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.37.2.tgz",
+      "integrity": "sha512-kUvzyvkcd6h1vpeMAojK2y7+PAV5H+0Cc9+ZlKYDFhDY31AlvsB+GW5vNO4qE3Y07KeQgvNO9U0QUx/fN62kBw==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "@types/cookie": "0.6.0",
+        "cookie": "0.7.1",
+        "jose": "^5.9.3",
+        "oauth4webapi": "^3.0.0",
+        "preact": "10.11.3",
+        "preact-render-to-string": "5.2.3"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -812,6 +844,15 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1072,6 +1113,12 @@
         "postcss": "^8.4.41",
         "tailwindcss": "4.0.6"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
@@ -1848,6 +1895,15 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3579,6 +3635,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4121,6 +4186,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.25",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.25.tgz",
+      "integrity": "sha512-2dJJw1sHQl2qxCrRk+KTQbeH+izFbGFPuJj5eGgBZFYyiYYtvlrBeUw1E/OJJxTRjuxbSYGnCTkUIRsIIW0bog==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.37.2"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0-0",
+        "nodemailer": "^6.6.5",
+        "react": "^18.2.0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -4147,6 +4239,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.3.1.tgz",
+      "integrity": "sha512-ZwX7UqYrP3Lr+Glhca3a1/nF2jqf7VVyJfhGuW5JtrfDUxt0u+IoBPzFjZ2dd7PJGkdM6CFPVVYzuDYKHv101A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {
@@ -4436,6 +4537,28 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/preact": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz",
+      "integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4540,6 +4663,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.475.0",
     "next": "15.1.7",
+    "next-auth": "^5.0.0-beta.25",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/src/app/(auth)/login/LoginForm.tsx
+++ b/src/app/(auth)/login/LoginForm.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useActionState } from 'react'
+import { signInWithCredentials } from './actions'
+
+export default function LoginForm() {
+  const [state, formAction] = useActionState(signInWithCredentials, { message: '' })
+
+  return (
+    <form action={formAction} className='flex flex-col'>
+      <label className='form-control'>
+        <span className='label-text'>이메일</span>
+        <input name='email' type='email' className='input input-bordered' required />
+      </label>
+
+      <label className='form-control'>
+        <span className='label-text'>비밀번호</span>
+        <input name='password' type='password' className='input input-bordered' required />
+      </label>
+
+      {state?.message && (
+        <div className='mt-2 text-sm text-red-500'>
+          <p>메세지창</p>
+          <p>{state.message}</p>
+        </div>
+      )}
+
+      <button type='submit' className='btn btn-primary'>
+        로그인
+      </button>
+    </form>
+  )
+}

--- a/src/app/(auth)/login/actions.ts
+++ b/src/app/(auth)/login/actions.ts
@@ -1,0 +1,40 @@
+'use server'
+
+import { signIn } from '@/auth'
+import { redirect } from 'next/navigation'
+
+export const signInWithCredentials = async (
+  state: { message: string } = { message: '' },
+  formData: FormData
+) => {
+  try {
+    await signIn('credentials', {
+      email: formData.get('email') || '',
+      password: formData.get('password') || '',
+
+      // redirectTo는 try 문 안에서 동작하지 않지만 명시적으로 redirect 호출해야 함
+      redirect: false, // false로 해두고 아래에서 직접 처리하기
+    })
+  } catch (error) {
+    const e = error as Error & {
+      cause?: { err?: { message?: string } }
+    }
+
+    const errorCode = e?.cause?.err?.message ?? ''
+
+    switch (errorCode) {
+      case 'USER_NOT_FOUND':
+        return { ...state, message: '가입되지 않은 이메일 주소입니다.' }
+      case 'NOT_VALID_PASSWORD':
+        return { ...state, message: '비밀번호가 일치하지 않습니다.' }
+      case 'UNEXPECTED_ERROR':
+        throw new Error('UNEXPECTED_ERROR')
+      // 코드 오류나 프레임워크 내부 예외 등 완전히 예상치 못한 예외 (ex. NEXT_REDIRECT, CallbackRouteError, ReferenceError 등)
+      default:
+        console.error(error)
+        // TODO: error.tsx 제대로 구현 후 error도 넘겨주게 변경
+        throw new Error('UNHANDLED_ERROR')
+    }
+  }
+  redirect('/') // 로그인 성공시 홈으로 리디렉션
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,3 +1,16 @@
+import Link from 'next/link'
+import LoginForm from './LoginForm'
+
 export default function LoginPage() {
-  return <div>로그인 페이지</div>
+  return (
+    <div>
+      <h2>로그인 페이지</h2>
+      <div>
+        <LoginForm />
+        <Link href='/register' className='btn btn-secondary'>
+          회원가입
+        </Link>
+      </div>
+    </div>
+  )
 }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,2 @@
+import { handlers } from '@/auth'
+export const { GET, POST } = handlers

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+export default function Error() {
+  return (
+    <>
+      <h2>에러페이지</h2>
+      <p>예상치 못한 에러입니다</p>
+    </>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import './globals.css'
 import TopNav from '@/components/layout/TopNav'
 import BottomNav from '@/components/layout/BottomNav'
+import Providers from '@/providers/providers'
 
 export const metadata: Metadata = {
   title: 'Deepdiview',
@@ -15,15 +16,17 @@ export default function RootLayout({
   return (
     <html lang='ko'>
       <body>
-        <div className='mx-auto max-w-[1440px] px-4 sm:px-6 lg:px-8'>
-          <header>
-            <TopNav />
-          </header>
-          <main>{children}</main>
-          <footer>
-            <BottomNav />
-          </footer>
-        </div>
+        <Providers>
+          <div className='mx-auto max-w-[1440px] px-4 sm:px-6 lg:px-8'>
+            <header>
+              <TopNav />
+            </header>
+            <main>{children}</main>
+            <footer>
+              <BottomNav />
+            </footer>
+          </div>
+        </Providers>
       </body>
     </html>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,7 @@
 export default function HomePage() {
-  return <div>홈페이지</div>
+  return (
+    <>
+      <h2>홈페이지</h2>
+    </>
+  )
 }

--- a/src/app/profile/[id]/actions.ts
+++ b/src/app/profile/[id]/actions.ts
@@ -1,0 +1,24 @@
+'use server'
+
+import { auth, signOut } from '@/auth'
+import { apiClient } from '@/lib/apiClient'
+import { redirect } from 'next/navigation'
+
+export const signOutWithForm = async () => {
+  try {
+    const session = await auth()
+    const accessToken = session?.accessToken
+
+    await apiClient('/users/logout', {
+      method: 'DELETE',
+      withAuth: true,
+      token: accessToken,
+    })
+
+    await signOut({ redirect: false })
+  } catch (error) {
+    console.error(error)
+    throw new Error('UNHANDLED_ERROR')
+  }
+  redirect('/')
+}

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,3 +1,24 @@
-export default function ProfilePage() {
-  return <div>프로필 페이지</div>
+import { auth } from '@/auth'
+import { signOutWithForm } from './actions'
+
+export default async function ProfilePage({ params: { id } }: { params: { id: string } }) {
+  const session = await auth()
+  const userId = session.user.userId
+  return (
+    <div>
+      <h2>프로필 페이지</h2>
+      {userId === Number(id) ? (
+        <>
+          <h3>내 프로필</h3>
+          <form action={signOutWithForm}>
+            <button className='btn'>로그아웃</button>
+          </form>
+        </>
+      ) : (
+        <>
+          <h3>다른 사람 프로필</h3>
+        </>
+      )}
+    </div>
+  )
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,61 @@
+import NextAuth from 'next-auth'
+import Credentials from 'next-auth/providers/credentials'
+import { apiClient } from './lib/apiClient'
+
+export const { handlers, signIn, signOut, auth } = NextAuth({
+  providers: [
+    Credentials({
+      authorize: async (credentials) => {
+        try {
+          if (!credentials?.email || !credentials?.password) {
+            throw new Error('❌ [authorize] 이메일, 비밀번호 누락')
+          }
+
+          // TODO: 로그인 API 모듈 분리 및 타입 정의 예정
+          const user = await apiClient<LoginResponse, LoginRequest>('/users/login', {
+            method: 'POST',
+            body: {
+              email: credentials.email,
+              password: credentials.password,
+            },
+          })
+
+          console.log('✅ [authorize] 로그인 성공')
+          return user
+        } catch (error) {
+          console.error('❌ [authorize] 로그인 실패:', error)
+
+          const e = error as Error
+          throw new Error(e.message)
+        }
+      },
+    }),
+  ],
+  secret: process.env.NEXTAUTH_SECRET,
+  session: {
+    strategy: 'jwt',
+    maxAge: 60 * 60 * 24 * 15 - 60 * 10, // refreshToken 유효기간(15일) 10분 전,
+  },
+  pages: {
+    signIn: '/login',
+  },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        Object.assign(token, user) // 이미 필요한것만 받아서 다 넣음
+      }
+      return token
+    },
+    async session({ session, token }) {
+      session.user = {
+        userId: token.userId,
+        email: token.email,
+        nickname: token.nickname,
+        profileImageUrl: token.profileImageUrl,
+        role: token.role,
+      }
+      session.accessToken = token.accessToken // refreshToken은 보안을 위해 넣지 않음
+      return session
+    },
+  },
+})

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -1,11 +1,16 @@
 'use client'
-import { Bell, Home, NotebookPen, Search, UserRound } from 'lucide-react'
+
+import { Bell, Home, KeyRound, NotebookPen, Search, UserRound } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import clsx from 'clsx'
+import { useSession } from 'next-auth/react'
 
 export default function BottomNav() {
   const pathname = usePathname()
+  // TODO: 바로 세션 변화 알아차리게 구현
+  const { data: session } = useSession()
+
   return (
     <nav className='dock md:hidden'>
       <Link href='/' className={clsx({ 'dock-active text-primary': pathname === '/' })}>
@@ -30,10 +35,12 @@ export default function BottomNav() {
         <Bell />
       </Link>
       <Link
-        href='/profile'
-        className={clsx({ 'dock-active text-primary': pathname.startsWith('/profile') })}
+        href={session?.user ? `/profile/${session.user.userId}` : '/login'}
+        className={clsx({
+          'dock-active text-primary': pathname.startsWith('/profile'),
+        })}
       >
-        <UserRound />
+        {session?.user ? <UserRound /> : <KeyRound />}
       </Link>
     </nav>
   )

--- a/src/components/layout/TopNav.tsx
+++ b/src/components/layout/TopNav.tsx
@@ -1,8 +1,13 @@
+'use client'
+
 import { Search } from 'lucide-react'
-import Image from 'next/image'
+import { useSession } from 'next-auth/react'
 import Link from 'next/link'
 
 export default function TopNav() {
+  // TODO: 바로 세션 변화 알아차리게 구현
+  const { data: session } = useSession()
+
   return (
     <nav className='navbar hidden px-0 md:flex'>
       <div className='flex-1'>
@@ -30,18 +35,22 @@ export default function TopNav() {
         >
           <span className='text-base'>알림</span>
         </Link>
-        <Link
-          href='/profile'
-          className='btn btn-ghost btn-circle avatar border-base-content hover:border-primary border-2'
-        >
-          <div className='relative w-full rounded-full'>
-            <Image
-              src='https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp'
-              alt='프로필 사진'
-              fill
-            />
-          </div>
-        </Link>
+
+        {session?.user ? (
+          <Link
+            className='btn btn-ghost hover:text-primary pl-0 hover:border-transparent hover:bg-transparent hover:shadow-none'
+            href={`/profile/${session.user.userId}`}
+          >
+            프로필
+          </Link>
+        ) : (
+          <Link
+            className='btn btn-ghost hover:text-primary pl-0 hover:border-transparent hover:bg-transparent hover:shadow-none'
+            href='/login'
+          >
+            로그인
+          </Link>
+        )}
       </div>
     </nav>
   )

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -39,6 +39,7 @@ export async function apiClient<T, B = undefined>(
   let res: Response
   try {
     res = await fetch(fullUrl, fetchOptions)
+    console.info(`✅ [apiClient] ${method} ${path} → ${res.status}`)
   } catch (err) {
     console.error(`❌ [apiClient] 네트워크 에러: ${method} ${path}`)
     console.error(err)
@@ -48,7 +49,11 @@ export async function apiClient<T, B = undefined>(
   let data: unknown
 
   try {
-    data = await res.json()
+    if (res.status === 204) {
+      data = null
+    } else {
+      data = await res.json()
+    }
   } catch {
     const raw = await res.text()
     console.error('❌ [apiClient] JSON 파싱 실패: ', raw)

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,0 +1,78 @@
+type ApiFetchOptions<B = undefined> = {
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE'
+  body?: B
+  headers?: Record<string, string>
+  withAuth?: boolean
+  token?: string | null
+  cache?: RequestCache
+}
+
+export async function apiClient<T, B = undefined>(
+  path: string,
+  {
+    method = 'GET',
+    body,
+    headers = {},
+    withAuth = false,
+    token,
+    cache = 'no-store',
+  }: ApiFetchOptions<B> = {}
+): Promise<T> {
+  const fullUrl = `${process.env.NEXT_PUBLIC_API_URL}${path}`
+
+  const finalHeaders: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...headers,
+  }
+
+  if (withAuth && token) {
+    finalHeaders['Authorization'] = `Bearer ${token}`
+  }
+
+  const fetchOptions: RequestInit = {
+    method,
+    headers: finalHeaders,
+    body: body ? JSON.stringify(body) : undefined,
+    cache,
+  }
+
+  let res: Response
+  try {
+    res = await fetch(fullUrl, fetchOptions)
+  } catch (err) {
+    console.error(`❌ [apiClient] 네트워크 에러: ${method} ${path}`)
+    console.error(err)
+    throw new Error('NETWORK_ERROR')
+  }
+
+  let data: unknown
+
+  try {
+    data = await res.json()
+  } catch {
+    const raw = await res.text()
+    console.error('❌ [apiClient] JSON 파싱 실패: ', raw)
+    throw new Error('INVALID_JSON_RESPONSE')
+  }
+
+  if (!res.ok) {
+    // errorCode가 없는 경우 (ex: "message": "Unauthorized") 등 예상 못 한 응답 포맷 대비용
+    const maybeError = data as Record<string, unknown>
+
+    const errorCode =
+      typeof maybeError.errorCode === 'string' ? maybeError.errorCode : 'UNEXPECTED_ERROR'
+
+    console.error(`❌ [apiClient] API 에러: ${method} ${path}`)
+    console.error(`📦 상태 코드: ${res.status}`)
+    console.error(`📦 에러 코드: ${errorCode}`)
+
+    // 디버깅을 위해 전체 응답 출력
+    if (errorCode === 'UNEXPECTED_ERROR') {
+      console.error('🧾 예상치 못한 에러 응답:', data)
+    }
+
+    throw new Error(errorCode)
+  }
+
+  return data as T
+}

--- a/src/providers/providers.tsx
+++ b/src/providers/providers.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { SessionProvider } from 'next-auth/react'
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>
+}


### PR DESCRIPTION
## 💡 Description
- Auth.js (구 NextAuth.js)를 사용해 인증 로직 구현
- 로그인/로그아웃 API 호출을 위한 `apiClient` 유틸 추가
- 클라이언트에서 세션 정보를 사용할 수 있도록 `SessionProvider` 구현

## ✨ Changes
- Auth.js 기반 인증 로직 추가
- 로그인/로그아웃 API 클라이언트 유틸(apiClient) 추가
- `SessionProvider`로 클라이언트 세션 접근 가능하게 처리
- 로그인 페이지 구현
- 프로필 페이지에 로그아웃 버튼 추가

## ✏️ Notes
- Type Error로 인해 빌드가 실패했지만, 이번 작업은 일단 머지 진행
- 다음 작업에서 API 함수 및 타입 정의로 해결될 예정