### PR TITLE
[Feature] API 타입/함수 구현, NextAuth 타입 확장

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["NEXTAUTH"]
+  "cSpell.words": ["Deepdiview", "NEXTAUTH", "pageable", "tmdb"]
 }

--- a/src/app/profile/[id]/actions.ts
+++ b/src/app/profile/[id]/actions.ts
@@ -1,20 +1,16 @@
 'use server'
 
 import { auth, signOut } from '@/auth'
-import { apiClient } from '@/lib/apiClient'
+import { logout } from '@/lib/api/user'
 import { redirect } from 'next/navigation'
 
 export const signOutWithForm = async () => {
   try {
     const session = await auth()
     const accessToken = session?.accessToken
-
-    await apiClient('/users/logout', {
-      method: 'DELETE',
-      withAuth: true,
-      token: accessToken,
-    })
-
+    if (accessToken) {
+      await logout(accessToken)
+    }
     await signOut({ redirect: false })
   } catch (error) {
     console.error(error)

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,9 +1,11 @@
 import { auth } from '@/auth'
 import { signOutWithForm } from './actions'
 
-export default async function ProfilePage({ params: { id } }: { params: { id: string } }) {
+export default async function ProfilePage({ params }: { params: Promise<{ id: string }> }) {
   const session = await auth()
-  const userId = session.user.userId
+  const userId = session?.user?.userId
+  const { id } = await params
+
   return (
     <div>
       <h2>프로필 페이지</h2>

--- a/src/lib/api/certification.ts
+++ b/src/lib/api/certification.ts
@@ -1,0 +1,84 @@
+import {
+  CreateCertificationRequest,
+  CreateCertificationResponse,
+  GetCertificationResponse,
+  GetCertificationsParams,
+  GetCertificationsResponse,
+  UpdateCertificationRequest,
+  UpdateCertificationResponse,
+  UpdateCertificationStatusRequest,
+} from '@/types/api/certification'
+import { apiClient } from '../apiClient'
+import { toQueryString } from '../utils/query'
+
+// 인증샷 수정
+export async function updateCertification(
+  body: UpdateCertificationRequest,
+  token: string
+): Promise<UpdateCertificationResponse> {
+  return apiClient<UpdateCertificationResponse, UpdateCertificationRequest>(`/certifications`, {
+    method: 'PUT',
+    body,
+    withAuth: true,
+    token,
+  })
+}
+
+// 인증샷 제출
+export async function createCertification(
+  body: CreateCertificationRequest,
+  token: string
+): Promise<CreateCertificationResponse> {
+  return apiClient<CreateCertificationResponse, CreateCertificationRequest>(`/certifications`, {
+    method: 'POST',
+    body,
+    withAuth: true,
+    token,
+  })
+}
+
+// 인증샷 삭제
+export async function deleteCertification(token: string) {
+  return apiClient(`/certifications`, {
+    method: 'DELETE',
+    withAuth: true,
+    token,
+  })
+}
+
+// 인증 승인/거절
+export async function updateCertificationStatus(
+  id: string | number,
+  token: string,
+  body: UpdateCertificationStatusRequest
+): Promise<null> {
+  return apiClient<null, UpdateCertificationStatusRequest>(
+    `/certifications/admin/proceeding/${id}`,
+    {
+      method: 'POST',
+      body,
+      withAuth: true,
+      token,
+    }
+  )
+}
+
+// 인증샷 상태 확인
+export async function getCertification(token: string): Promise<GetCertificationResponse> {
+  return apiClient<GetCertificationResponse>(`/certifications/me`, {
+    withAuth: true,
+    token,
+  })
+}
+
+// 인증 목록 조회
+export async function getCertifications(
+  token: string,
+  params?: GetCertificationsParams
+): Promise<GetCertificationsResponse> {
+  const query = params ? `?${toQueryString(params)}` : ''
+  return apiClient<GetCertificationsResponse>(`/certifications/admin${query}`, {
+    withAuth: true,
+    token,
+  })
+}

--- a/src/lib/api/comment.ts
+++ b/src/lib/api/comment.ts
@@ -1,0 +1,64 @@
+import {
+  CreateCommentRequest,
+  CreateCommentResponse,
+  GetCommentsParams,
+  GetCommentsResponse,
+  UpdateCommentsRequest,
+  UpdateCommentsResponse,
+} from '@/types/api/comment'
+import { apiClient } from '../apiClient'
+import { toQueryString } from '../utils/query'
+
+// 댓글 수정
+export async function updateComments(
+  reviewId: string,
+  commentId: string,
+  body: UpdateCommentsRequest,
+  token: string
+): Promise<UpdateCommentsResponse> {
+  return apiClient<UpdateCommentsResponse, UpdateCommentsRequest>(
+    `/reviews/${reviewId}/comments/${commentId}`,
+    {
+      method: 'PUT',
+      body,
+      withAuth: true,
+      token,
+    }
+  )
+}
+
+// 댓글 삭제
+export async function deleteComments(
+  reviewId: string,
+  commentId: string,
+  token: string
+): Promise<null> {
+  return apiClient<null>(`/reviews/${reviewId}/comments/${commentId}`, {
+    method: 'DELETE',
+    withAuth: true,
+    token,
+  })
+}
+
+// 특정 리뷰에 달린 댓글 조회
+export async function getComments(
+  reviewId: string,
+  params?: GetCommentsParams
+): Promise<GetCommentsResponse> {
+  const query = params ? `?${toQueryString(params)}` : ''
+  return apiClient<GetCommentsResponse>(`/reviews/${reviewId}/comments${query}`)
+}
+
+// 댓글 작성
+export async function createComment(
+  reviewId: string,
+  token: string,
+  body: CreateCommentRequest
+): Promise<CreateCommentResponse> {
+  return apiClient<CreateCommentResponse, CreateCommentRequest>(`/reviews/${reviewId}/comments`, {
+    method: 'POST',
+    body,
+    withAuth: true,
+    token,
+  })
+}

--- a/src/lib/api/discussion.ts
+++ b/src/lib/api/discussion.ts
@@ -1,0 +1,30 @@
+import {
+  CreateBoardReviewRequest,
+  CreateBoardReviewResponse,
+  GetIsSundayResponse,
+  GetThisWeekMovieIdResponse,
+} from '@/types/api/discussion'
+import { apiClient } from '../apiClient'
+
+// 인증승인된 사용자의 토론 게시판 리뷰 작성
+export async function createBoardReview(
+  token: string,
+  body: CreateBoardReviewRequest
+): Promise<CreateBoardReviewResponse> {
+  return apiClient<CreateBoardReviewResponse, CreateBoardReviewRequest>(`/discussions/reviews`, {
+    method: 'POST',
+    body,
+    withAuth: true,
+    token,
+  })
+}
+
+// 이번주 토론 영화(= 지난주 1위 영화) id 조회
+export async function getThisWeekMovieId(): Promise<GetThisWeekMovieIdResponse> {
+  return apiClient<GetThisWeekMovieIdResponse>('/discussions/this-week-movie')
+}
+
+// 일요일인지 여부 T/F
+export async function getIsSunday(): Promise<GetIsSundayResponse> {
+  return apiClient<GetIsSundayResponse>('/discussions/is-sunday')
+}

--- a/src/lib/api/movie.ts
+++ b/src/lib/api/movie.ts
@@ -1,0 +1,23 @@
+import {
+  GetMovieResponse,
+  GetPopularMoviesResponse,
+  GetSearchedMoviesResponse,
+} from '@/types/api/movie'
+import { apiClient } from '../apiClient'
+
+// 특정 영화 상세정보 조회
+export async function getMovie(id: string): Promise<GetMovieResponse> {
+  return apiClient<GetMovieResponse>(`/movies/${id}`)
+}
+
+// 영화 제목으로 상세정보 조회 encodeURIComponent(title)이거 뭔지 알아보기
+export async function getSearchedMovies(title: string): Promise<GetSearchedMoviesResponse> {
+  return apiClient<GetSearchedMoviesResponse>(
+    `/movies/search/list?title=${encodeURIComponent(title)}`
+  )
+}
+
+// 넷플릭스 인기도 탑20의 영화 리스트 조회
+export async function getPopularMovies(): Promise<GetPopularMoviesResponse> {
+  return apiClient<GetPopularMoviesResponse>('/movies/popularity/top20')
+}

--- a/src/lib/api/notification.ts
+++ b/src/lib/api/notification.ts
@@ -1,0 +1,28 @@
+import { GetNotificationsResponse } from '@/types/api/notification'
+import { apiClient } from '../apiClient'
+
+// 특정 알림 읽음처리
+export async function readNotification(id: string, token: string): Promise<null> {
+  return apiClient<null>(`/notifications/${id}/read`, {
+    method: 'POST',
+    withAuth: true,
+    token,
+  })
+}
+
+// 전체 알림 읽음처리
+export async function readAllNotifications(token: string): Promise<null> {
+  return apiClient<null>(`/notifications/read-all`, {
+    method: 'POST',
+    withAuth: true,
+    token,
+  })
+}
+
+// 알림 목록 조회
+export async function getNotifications(token: string): Promise<GetNotificationsResponse> {
+  return apiClient<GetNotificationsResponse>('/notifications', {
+    withAuth: true,
+    token,
+  })
+}

--- a/src/lib/api/review.ts
+++ b/src/lib/api/review.ts
@@ -1,0 +1,70 @@
+import {
+  CreateReviewRequest,
+  CreateReviewResponse,
+  GetLatestReviewsResponse,
+  GetReviewResponse,
+  GetReviewsResponse,
+  UpdateReviewRequest,
+  UpdateReviewResponse,
+} from '@/types/api/review'
+import { apiClient } from '../apiClient'
+
+// 특정 리뷰 조회
+export async function getReview(id: string): Promise<GetReviewResponse> {
+  return apiClient<GetReviewResponse>(`/reviews/${id}`)
+}
+
+// 리뷰글 수정
+export async function updateReview(
+  id: string,
+  token: string,
+  body: UpdateReviewRequest
+): Promise<UpdateReviewResponse> {
+  return apiClient<UpdateReviewResponse, UpdateReviewRequest>(`/reviews/${id}`, {
+    method: 'PUT',
+    body,
+    withAuth: true,
+    token,
+  })
+}
+
+// 리뷰글 삭제
+export async function deleteReview(id: string, token: string): Promise<null> {
+  return apiClient<null>(`/reviews/${id}`, {
+    method: 'DELETE',
+    withAuth: true,
+    token,
+  })
+}
+
+// 리뷰글 작성
+export async function createReview(
+  token: string,
+  body: CreateReviewRequest
+): Promise<CreateReviewResponse> {
+  return apiClient<CreateReviewResponse, CreateReviewRequest>(`/reviews`, {
+    method: 'POST',
+    body,
+    withAuth: true,
+    token,
+  })
+}
+
+// 좋아요
+export async function likeReview(id: string, token: string): Promise<null> {
+  return apiClient<null>(`/reviews/like/${id}`, {
+    method: 'POST',
+    withAuth: true,
+    token,
+  })
+}
+
+// 특정 영화에 대한 리뷰 조회 (쿼리)
+export async function getReviews(id: string): Promise<GetReviewsResponse> {
+  return apiClient<GetReviewsResponse>(`/reviews/movie/${id}`)
+}
+
+// 최신 리뷰 3개 조회 (쿼리)
+export async function getLatestReviews(): Promise<GetLatestReviewsResponse> {
+  return apiClient<GetLatestReviewsResponse>(`/reviews/latest`)
+}

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -1,0 +1,164 @@
+import {
+  CreateProfileImgRequest,
+  CreateProfileImgResponse,
+  DeleteMyProfileRequest,
+  GetMyProfileResponse,
+  GetUserCommentsParams,
+  GetUserCommentsResponse,
+  GetUserProfileResponse,
+  GetUserReviewsParams,
+  GetUserReviewsResponse,
+  LoginRequest,
+  LoginResponse,
+  RefreshAccessTokenResponse,
+  RegisterRequest,
+  UpdateIntroRequest,
+  UpdateMyProfileRequest,
+  UpdateProfileImgRequest,
+  UpdateProfileImgResponse,
+} from '@/types/api/user'
+import { apiClient } from '../apiClient'
+import { toQueryString } from '../utils/query'
+
+// 프로필사진 수정
+export async function updateProfileImg(
+  token: string,
+  body: UpdateProfileImgRequest
+): Promise<UpdateProfileImgResponse> {
+  return apiClient<UpdateProfileImgResponse, UpdateProfileImgRequest>(`/users/profile-image`, {
+    method: 'PUT',
+    body,
+    withAuth: true,
+    token,
+  })
+}
+
+// 프로필사진 등록
+export async function createProfileImg(
+  token: string,
+  body: CreateProfileImgRequest
+): Promise<CreateProfileImgResponse> {
+  return apiClient<CreateProfileImgResponse, CreateProfileImgRequest>(`/users/profile-image`, {
+    method: 'POST',
+    body,
+    withAuth: true,
+    token,
+  })
+}
+
+// 프로필사진 삭제
+export async function deleteProfileImg(token: string): Promise<null> {
+  return apiClient<null>(`/users/profile-image`, {
+    method: 'DELETE',
+    withAuth: true,
+    token,
+  })
+}
+
+// 내 정보 확인
+export async function getMyProfile(token: string): Promise<GetMyProfileResponse> {
+  return apiClient<GetMyProfileResponse>(`/users/me`, {
+    withAuth: true,
+    token,
+  })
+}
+
+// 회원정보 수정
+export async function updateMyProfile(token: string, body: UpdateMyProfileRequest): Promise<null> {
+  return apiClient<null, UpdateMyProfileRequest>(`/users/me`, {
+    method: 'PUT',
+    body,
+    withAuth: true,
+    token,
+  })
+}
+
+// 회원탈퇴
+export async function deleteMyProfile(token: string, body: DeleteMyProfileRequest): Promise<null> {
+  return apiClient<null, DeleteMyProfileRequest>(`/users/me`, {
+    method: 'POST',
+    body,
+    withAuth: true,
+    token,
+  })
+}
+
+// 한줄소개 설정/수정
+export async function updateIntro(token: string, body: UpdateIntroRequest): Promise<null> {
+  return apiClient<null, UpdateIntroRequest>(`/users/me/intro`, {
+    method: 'PUT',
+    body,
+    withAuth: true,
+    token,
+  })
+}
+
+// 회원가입
+export async function register(body: RegisterRequest): Promise<null> {
+  return apiClient<null, RegisterRequest>('/users/signup', {
+    method: 'POST',
+    body,
+  })
+}
+
+// 리프레시 토큰으로 엑세스 토큰 재발급
+export async function refreshAccessToken(
+  refreshToken: string
+): Promise<RefreshAccessTokenResponse> {
+  return apiClient<RefreshAccessTokenResponse>('/users/reissue-access-token', {
+    method: 'POST',
+    withAuth: true,
+    token: refreshToken,
+  })
+}
+
+// 로그인
+export async function login(body: LoginRequest): Promise<LoginResponse> {
+  return apiClient<LoginResponse, LoginRequest>('/users/login', {
+    method: 'POST',
+    body,
+  })
+}
+
+// 다른 유저 정보 확인
+export async function getUserProfile(token: string, id: string): Promise<GetUserProfileResponse> {
+  return apiClient<GetUserProfileResponse>(`/users/${id}`, {
+    withAuth: true,
+    token,
+  })
+}
+
+// 특정 사용자가 작성한 리뷰 조회
+export async function getUserReviews(
+  token: string,
+  id: string,
+  params?: GetUserReviewsParams
+): Promise<GetUserReviewsResponse> {
+  const query = params ? `?${toQueryString(params)}` : ''
+  return apiClient<GetUserReviewsResponse>(`/users/${id}/reviews${query}`, {
+    withAuth: true,
+    token,
+  })
+}
+
+// 특정 사용자가 작성한 댓글 조회
+export async function getUserComments(
+  token: string,
+  id: string,
+  params?: GetUserCommentsParams
+): Promise<GetUserCommentsResponse> {
+  const query = params ? `?${toQueryString(params)}` : ''
+  return apiClient<GetUserCommentsResponse>(`/users/${id}/comments${query}`, {
+    withAuth: true,
+    token,
+  })
+}
+
+// 로그아웃
+export async function logout(token: string): Promise<null> {
+  return apiClient<null>(`/users/logout`, {
+    method: 'DELETE',
+    withAuth: true,
+    token,
+  })
+}

--- a/src/lib/api/vote.ts
+++ b/src/lib/api/vote.ts
@@ -1,0 +1,69 @@
+import {
+  CreateVoteResponse,
+  GetVoteLatestResultResponse,
+  GetVoteOptionsResponse,
+  GetVoteParticipationStatusResponse,
+  GetVoteResultResponse,
+  ParticipateVoteRequest,
+  ParticipateVoteResponse,
+} from '@/types/api/vote'
+import { apiClient } from '../apiClient'
+
+// 투표 생성
+export async function createVote(token: string): Promise<CreateVoteResponse> {
+  return apiClient<CreateVoteResponse>(`/votes`, {
+    method: 'POST',
+    withAuth: true,
+    token,
+  })
+}
+
+// 현재 진행중인 투표에 참여하기
+export async function participateVote(
+  token: string,
+  body: ParticipateVoteRequest
+): Promise<ParticipateVoteResponse> {
+  return apiClient<ParticipateVoteResponse, ParticipateVoteRequest>('/votes/participate', {
+    method: 'POST',
+    body,
+    withAuth: true,
+    token,
+  })
+}
+
+// 현재 진행중인 투표 결과 확인
+export async function getVoteResult(): Promise<GetVoteResultResponse> {
+  return apiClient<GetVoteResultResponse>(`/votes/result`)
+}
+
+// 지난주 투표 전체 결과 조회
+export async function getVoteLatestResult(): Promise<GetVoteLatestResultResponse> {
+  return apiClient<GetVoteLatestResultResponse>(`/votes/result/latest`)
+}
+
+// 현재 진행중인 투표에 참여했는지 여부 T/F
+export async function getVoteParticipationStatus(
+  token: string
+): Promise<GetVoteParticipationStatusResponse> {
+  return apiClient<GetVoteParticipationStatusResponse>(`/votes/participation-status`, {
+    withAuth: true,
+    token,
+  })
+}
+
+// 현재 진행중인 투표의 선택지 조회
+export async function getVoteOptions(token: string): Promise<GetVoteOptionsResponse> {
+  return apiClient<GetVoteOptionsResponse>(`/votes/options`, {
+    withAuth: true,
+    token,
+  })
+}
+
+// 투표 삭제
+export async function deleteVote(id: string, token: string): Promise<null> {
+  return apiClient<null>(`/votes/${id}`, {
+    method: 'DELETE',
+    withAuth: true,
+    token,
+  })
+}

--- a/src/lib/utils/query.ts
+++ b/src/lib/utils/query.ts
@@ -1,0 +1,11 @@
+export function toQueryString<T extends object>(params: T): string {
+  const query = new URLSearchParams()
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      query.append(key, String(value))
+    }
+  })
+
+  return query.toString()
+}

--- a/src/types/api/certification.ts
+++ b/src/types/api/certification.ts
@@ -1,0 +1,59 @@
+import {
+  CertificationRejectionReason,
+  CertificationStatus,
+  PaginatedResponse,
+  SortDirection,
+} from './common'
+
+// API 타입
+
+// 인증샷 수정
+export interface UpdateCertificationRequest {
+  file: string
+}
+export type UpdateCertificationResponse = CertificationPendingResponse
+
+// 인증샷 제출
+export interface CreateCertificationRequest {
+  file: string
+}
+export type CreateCertificationResponse = CertificationPendingResponse
+
+// 인증샷 삭제
+
+// 인증 승인/거절
+export interface UpdateCertificationStatusRequest {
+  approve: boolean
+  rejectionReason?: CertificationRejectionReason
+}
+
+// 인증샷 상태 확인
+export type GetCertificationResponse = Certification
+
+// 인증 목록 조회
+export interface GetCertificationsParams {
+  status?: CertificationStatus
+  page?: number
+  size?: number
+  sort?: `${SortField},${SortDirection}`
+}
+export type GetCertificationsResponse = PaginatedResponse<Certification>
+
+// 보조 타입
+export type CertificationPendingResponse = {
+  id: number
+  userId: number
+  certificationUrl: string
+  status: 'PENDING'
+  createdAt: string
+  rejectionReason: null
+}
+export interface Certification {
+  id: number
+  userId: number
+  certificationUrl: string
+  status: CertificationStatus
+  createdAt: string
+  rejectionReason: CertificationRejectionReason | null
+}
+export type SortField = 'id' | 'createdAt' | 'status'

--- a/src/types/api/comment.ts
+++ b/src/types/api/comment.ts
@@ -1,0 +1,30 @@
+import { Comment, PaginatedResponse, SortDirection } from './common'
+
+// API 타입
+
+// 댓글 수정
+export type UpdateCommentsRequest = CommentsRequest
+export type UpdateCommentsResponse = Comment
+
+// 댓글 삭제
+
+// 특정 리뷰에 달린 댓글 조회
+export interface GetCommentsParams {
+  page?: number
+  size?: number
+  sort?: `${SortField},${SortDirection}`
+}
+
+export type GetCommentsResponse = PaginatedResponse<Comment>
+
+// 댓글 작성
+export type CreateCommentParams = GetCommentsParams
+export type CreateCommentRequest = CommentsRequest
+export type CreateCommentResponse = Comment
+
+// 보조 타입
+export interface CommentsRequest {
+  content: string
+}
+
+export type SortField = 'id' | 'createdAt' | 'updatedAt'

--- a/src/types/api/common.ts
+++ b/src/types/api/common.ts
@@ -1,0 +1,77 @@
+export interface BaseUser {
+  userId: number
+  email: string
+  nickname: string
+  profileImageUrl: string | null
+  role: 'USER' | 'ADMIN'
+  accessToken: string
+  refreshToken: string
+}
+
+export type CertificationStatus = 'PENDING' | 'APPROVED' | 'REJECTED'
+
+export type CertificationRejectionReason =
+  | 'OTHER_MOVIE_IMAGE'
+  | 'WRONG_IMAGE'
+  | 'UNIDENTIFIABLE_IMAGE'
+
+export interface PageableInfo {
+  offset: number
+  sort: SortInfo
+  pageSize: number
+  paged: boolean
+  pageNumber: number
+  unpaged: boolean
+}
+
+export interface SortInfo {
+  empty: boolean
+  sorted: boolean
+  unsorted: boolean
+}
+
+export interface PaginatedResponse<T> {
+  totalElements: number
+  totalPages: number
+  size: number
+  content: T[]
+  number: number
+  sort: SortInfo
+  numberOfElements: number
+  pageable: PageableInfo
+  first: boolean
+  last: boolean
+  empty: boolean
+}
+
+export interface Review {
+  reviewId: number
+  userId: number
+  nickname: string
+  profileImageUrl: string
+  reviewTitle: string
+  reviewContent: string
+  rating: number
+  createdAt: string
+  updatedAt: string
+  likeCount: number
+  likedByUser: boolean
+  tmdbId: number
+  movieTitle: string
+  posterPath: string
+  certified: boolean
+  comments: Comment[]
+}
+
+export interface Comment {
+  id: number
+  reviewId: number
+  userId: number
+  userNickname: string
+  profileImageUrl: string
+  content: string
+  createdAt: string
+  updatedAt: string
+}
+
+export type SortDirection = 'asc' | 'desc'

--- a/src/types/api/discussion.ts
+++ b/src/types/api/discussion.ts
@@ -1,0 +1,22 @@
+import { Review } from './common'
+
+// API 타입
+
+// 인증승인된 사용자의 토론 게시판 리뷰 작성
+export interface CreateBoardReviewRequest {
+  title: string
+  content: string
+  rating: number
+}
+
+export type CreateBoardReviewResponse = Review
+
+// 이번주 토론 영화(= 지난주 1위 영화) id 조회
+export interface GetThisWeekMovieIdResponse {
+  tmdbId: number
+}
+
+// 일요일인지 여부 T/F
+export interface GetIsSundayResponse {
+  isSunday: boolean
+}

--- a/src/types/api/movie.ts
+++ b/src/types/api/movie.ts
@@ -1,0 +1,25 @@
+// API 타입
+
+import { Review } from './common'
+
+// 특정 영화 상세정보 조회
+export interface GetMovieResponse {
+  id: number
+  title: string
+  original_title: string
+  overview: string
+  release_date: string
+  popularity: number
+  poster_path: string
+  backdrop_path: string
+  genre_ids: number[]
+  genre_names: string[]
+  reviews: Review[]
+  myReview: Review | null
+}
+
+// 영화 제목으로 상세정보 조회
+export type GetSearchedMoviesResponse = GetMovieResponse[]
+
+// 넷플릭스 인기도 탑20의 영화 리스트 조회
+export type GetPopularMoviesResponse = GetMovieResponse[]

--- a/src/types/api/notification.ts
+++ b/src/types/api/notification.ts
@@ -1,0 +1,15 @@
+// API 타입
+// 특정 알림 읽음처리
+
+// 전체 알림 읽음처리
+
+// 알림 목록 조회
+export type GetNotificationsResponse = Notification[]
+
+// 보조 타입
+export interface Notification {
+  notificationId: number
+  message: string
+  createdAt: string
+  read: boolean
+}

--- a/src/types/api/review.ts
+++ b/src/types/api/review.ts
@@ -1,0 +1,50 @@
+import { CertificationStatus, PaginatedResponse, Review, SortDirection } from './common'
+
+// API 타입
+
+// 특정 리뷰 조회
+export type GetReviewResponse = Review
+
+// 리뷰글 수정
+export interface UpdateReviewRequest {
+  title: string
+  content: string
+  rating: number
+}
+export type UpdateReviewResponse = Review
+
+// 리뷰글 삭제
+
+// 리뷰글 작성
+export interface CreateReviewRequest {
+  tmdbId: number
+  title: string
+  content: string
+  rating: number
+}
+export interface GetCertificationsParams {
+  status?: CertificationStatus
+  page?: number
+  size?: number
+  sort?: `${SortField},${SortDirection}`
+}
+export type CreateReviewResponse = Review
+
+// 좋아요 204
+
+// 특정 영화에 대한 리뷰 조회
+export interface GetReviewsParams {
+  tmdbId: number
+  certifiedFilter?: boolean
+  page?: number
+  size?: number
+  sort?: `${SortField},${SortDirection}`
+}
+
+export type GetReviewsResponse = PaginatedResponse<Review>
+
+// 최신 리뷰 3개 조회 (쿼리)
+export type GetLatestReviewsResponse = Review[]
+
+// 보조 타입
+export type SortField = 'rating' | 'createdAt' | 'likeCount' | 'nickname'

--- a/src/types/api/user.ts
+++ b/src/types/api/user.ts
@@ -1,0 +1,113 @@
+import {
+  BaseUser,
+  CertificationRejectionReason,
+  CertificationStatus,
+  Comment,
+  PaginatedResponse,
+  Review,
+  SortDirection,
+} from './common'
+
+// API 타입
+
+// 프로필사진 수정
+export type UpdateProfileImgRequest = ProfileImgRequest
+export type UpdateProfileImgResponse = ProfileImgResponse
+
+// 프로필사진 등록
+export type CreateProfileImgRequest = ProfileImgRequest
+export type CreateProfileImgResponse = ProfileImgResponse
+
+// 프로필사진 삭제
+
+// 내 정보 확인
+export type GetMyProfileResponse = ProfileResponse
+
+// 회원정보 수정
+export interface UpdateMyProfileRequest {
+  newNickname: string
+  newPassword: string
+  newConfirmPassword: string
+}
+
+// 회원탈퇴
+export interface DeleteMyProfileRequest {
+  password: string
+}
+
+// 한줄소개 설정/수정
+export interface UpdateIntroRequest {
+  oneLineIntro: string
+}
+
+// 회원가입
+export interface RegisterRequest {
+  email: string
+  password: string
+  confirmPassword: string
+  nickname: string
+}
+
+// 리프레시 토큰으로 엑세스 토큰 재발급
+export interface RefreshAccessTokenResponse {
+  newAccessToken: string
+}
+
+// 로그인
+export interface LoginRequest {
+  email: string
+  password: string
+}
+
+export type LoginResponse = BaseUser
+
+// 다른 유저 정보 확인
+export type GetUserProfileResponse = ProfileResponse
+
+// 특정 사용자가 작성한 리뷰 조회
+export interface GetUserReviewsParams {
+  page?: number
+  size?: number
+  sort?: `${ReviewSortField},${SortDirection}`
+}
+
+export type GetUserReviewsResponse = PaginatedResponse<Review>
+
+// 특정 사용자가 작성한 댓글 조회
+export interface GetUserCommentsParams {
+  page?: number
+  size?: number
+  sort?: `${CommentSortField},${SortDirection}`
+}
+
+export type GetUserCommentsResponse = PaginatedResponse<Comment>
+
+// 로그아웃
+
+// 보조 타입
+export interface ProfileResponse {
+  nickname: string
+  email: string
+  profileImageUrl: string
+  oneLineIntro: string
+  reviewCount: number
+  commentCount: number
+  ratingDistribution: Partial<Record<Rating, number>>
+  certificationStatus: CertificationStatus
+  rejectionReason: CertificationRejectionReason | null
+}
+
+type Rating = '0.5' | '1.0' | '1.5' | '2.0' | '2.5' | '3.0' | '3.5' | '4.0' | '4.5' | '5.0'
+
+export interface ProfileImgRequest {
+  file: string
+}
+export interface ProfileImgResponse {
+  profileImageUrl: string
+}
+
+export type ReviewSortField = 'createdAt' | 'likeCount' | 'rating'
+// | 'updatedAt' | 'movieTitle' | 'user.nickname' | 'movie.tmdbId'
+
+export type CommentSortField = 'createdAt'
+// | 'id' | 'updatedAt' | 'user.nickname'

--- a/src/types/api/vote.ts
+++ b/src/types/api/vote.ts
@@ -1,0 +1,55 @@
+// API 타입
+
+// 투표 생성
+export interface CreateVoteResponse {
+  voteId: number
+  title: string
+  startDate: string
+  endDate: string
+  movieDetails: VoteMovie[]
+}
+
+// 현재 진행중인 투표에 참여하기
+export interface ParticipateVoteRequest {
+  tmdbId: number
+}
+
+export interface ParticipateVoteResponse {
+  voteSuccess: boolean
+  tmdbId: number
+}
+
+// 현재 진행중인 투표 결과 확인
+export type GetVoteResultResponse = VoteResult
+
+// 지난주 투표 전체 결과 조회
+export type GetVoteLatestResultResponse = VoteResult
+
+// 현재 진행중인 투표에 참여했는지 여부 T/F
+export interface GetVoteParticipationStatusResponse {
+  participated: boolean
+}
+
+// 현재 진행중인 투표의 선택지 조회
+export interface GetVoteOptionsResponse {
+  voteId: number
+  tmdbIds: number[]
+}
+
+// 투표 삭제
+
+// 보조 타입
+export interface VoteMovie {
+  tmdbId: number
+  voteCount: number
+  rank: number
+  lastVotedTime: string
+}
+
+export interface VoteResult {
+  voteId: number
+  startDate: string
+  endDate: string
+  results: VoteMovie[]
+  activating: boolean
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,5 +1,3 @@
-import { JWT } from 'next-auth/jwt'
-
 declare module 'next-auth' {
   interface User {
     userId: number
@@ -15,7 +13,7 @@ declare module 'next-auth' {
   }
 }
 
-declare module 'next-auth/jwt' {
+export declare module '@auth/core/jwt' {
   interface JWT {
     userId: number
     nickname: string

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,27 @@
+import { JWT } from 'next-auth/jwt'
+
+declare module 'next-auth' {
+  interface User {
+    userId: number
+    nickname: string
+    profileImageUrl: string | null
+    role: 'USER' | 'ADMIN'
+    accessToken: string
+    refreshToken: string
+  }
+
+  interface Session {
+    accessToken: string
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    userId: number
+    nickname: string
+    profileImageUrl: string | null
+    role: 'USER' | 'ADMIN'
+    accessToken: string
+    refreshToken: string
+  }
+}


### PR DESCRIPTION
## 💡 Description
- Swagger 명세 기반으로 타입 정의 및 API 함수 구현
- NextAuth 관련 타입 확장

## ✨ Changes
- 컨트롤러 단위로 타입 정의 및 `apiClient` 기반 API 함수 파일 정리
- API별로 `Request`, `Response`, `Params` 타입 1:1 정의
- 공통 및 보조 타입 추가
- 실제 로그인 응답 스펙에 맞춰 Auth.js의 `User`, `Session`, `JWT` 타입 확장