### PR TITLE
[Feature] 비밀번호 변경 페이지 API 연동

### DIFF
--- a/src/app/profile/settings/password/PasswordForm.tsx
+++ b/src/app/profile/settings/password/PasswordForm.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useActionState } from 'react'
+import { updatePasswordAction } from './actions'
+
+export default function PasswordForm() {
+  const [state, formAction] = useActionState(updatePasswordAction, {
+    message: '',
+  })
+
+  return (
+    <form action={formAction}>
+      <input
+        className='input input-bordered'
+        placeholder='비밀번호'
+        type='password'
+        name='newPassword'
+        required
+      />
+      <input
+        className='input input-bordered'
+        placeholder='비밀번호 확인'
+        type='password'
+        name='newConfirmPassword'
+        required
+      />
+      {state?.message && (
+        <div className='mt-2 text-sm text-red-500'>
+          <p>메세지창</p>
+          <p>{state.message}</p>
+        </div>
+      )}
+      <button className='btn' type='submit'>
+        비밀번호 변경
+      </button>
+    </form>
+  )
+}

--- a/src/app/profile/settings/password/actions.ts
+++ b/src/app/profile/settings/password/actions.ts
@@ -1,0 +1,52 @@
+'use server'
+
+import { auth } from '@/auth'
+import { updatePassword } from '@/lib/api/user'
+import { redirect } from 'next/navigation'
+
+export const updatePasswordAction = async (
+  state: { message: string } = { message: '' },
+  formData: FormData
+) => {
+  const session = await auth()
+  if (!session?.user) throw new Error('UNAUTHORIZED')
+  const userId = session.user?.userId
+
+  // TODO: 유효성 검사 (zod)
+  const newPassword = formData.get('newPassword') as string
+  const newConfirmPassword = formData.get('newConfirmPassword') as string
+
+  try {
+    await updatePassword(session.accessToken, {
+      newPassword,
+      newConfirmPassword,
+    })
+  } catch (error: unknown) {
+    // TODO: VALIDATION_FAILED 에러 처리 개선 (에러 타입 정의, Zod 연동)
+    // 현재는 validErrors 메시지를 조합해서 단일 message로만 반환
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'errorCode' in error &&
+      (error as { errorCode: string }).errorCode === 'VALIDATION_FAILED' &&
+      'validErrors' in error &&
+      typeof (error as { validErrors: unknown }).validErrors === 'object'
+    ) {
+      const messages = Object.values((error as { validErrors: Record<string, string> }).validErrors)
+      const combinedMessage = messages.join('/')
+      return { ...state, message: combinedMessage || '입력값 오류' }
+    }
+    if (error instanceof Error) {
+      const errorCode = error.message
+      if (errorCode === 'NOT_VALID_PASSWORD') {
+        return { ...state, message: '비밀번호가 일치하지 않습니다.' }
+      }
+    }
+
+    // 코드 오류나 프레임워크 내부 예외 등 완전히 예상치 못한 예외 (ex. NEXT_REDIRECT, CallbackRouteError, ReferenceError 등)
+    console.error(error)
+    // TODO: error.tsx 제대로 구현 후 error도 넘겨주게 변경
+    throw new Error('UNHANDLED_ERROR')
+  }
+  redirect(`/profile/${userId}`)
+}

--- a/src/app/profile/settings/password/page.tsx
+++ b/src/app/profile/settings/password/page.tsx
@@ -1,0 +1,10 @@
+import PasswordForm from './PasswordForm'
+
+export default function SettingsPasswordPage() {
+  return (
+    <>
+      <h2>비밀번호 설정 페이지</h2>
+      <PasswordForm />
+    </>
+  )
+}

--- a/src/app/profile/settings/user-info/page.tsx
+++ b/src/app/profile/settings/user-info/page.tsx
@@ -1,3 +1,0 @@
-export default function SettingUserInfoPage() {
-  return <div>유저 정보 닉네임, 비밀번호 설정 페이지</div>
-}

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -13,7 +13,7 @@ import {
   RefreshAccessTokenResponse,
   RegisterRequest,
   UpdateIntroRequest,
-  UpdateMyProfileRequest,
+  UpdatePasswordRequest,
   UpdateProfileImgRequest,
   UpdateProfileImgResponse,
 } from '@/types/api/user'
@@ -55,19 +55,19 @@ export async function deleteProfileImg(token: string): Promise<null> {
   })
 }
 
-// 내 정보 확인
-export async function getMyProfile(token: string): Promise<GetMyProfileResponse> {
-  return apiClient<GetMyProfileResponse>(`/users/me`, {
+// 비밀번호 수정
+export async function updatePassword(token: string, body: UpdatePasswordRequest): Promise<null> {
+  return apiClient<null, UpdatePasswordRequest>(`/users/me/password`, {
+    method: 'PUT',
+    body,
     withAuth: true,
     token,
   })
 }
 
-// 회원정보 수정
-export async function updateMyProfile(token: string, body: UpdateMyProfileRequest): Promise<null> {
-  return apiClient<null, UpdateMyProfileRequest>(`/users/me`, {
-    method: 'PUT',
-    body,
+// 내 정보 확인
+export async function getMyProfile(token: string): Promise<GetMyProfileResponse> {
+  return apiClient<GetMyProfileResponse>(`/users/me`, {
     withAuth: true,
     token,
   })

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -71,6 +71,12 @@ export async function apiClient<T, B = undefined>(
     console.error(`📦 상태 코드: ${res.status}`)
     console.error(`📦 에러 코드: ${errorCode}`)
 
+    // VALIDATION_FAILED일 경우 전체 에러 응답 그대로 throw
+    if (errorCode === 'VALIDATION_FAILED') {
+      console.error('🧾 검증 실패 응답:', data)
+      throw data
+    }
+
     // 디버깅을 위해 전체 응답 출력
     if (errorCode === 'UNEXPECTED_ERROR') {
       console.error('🧾 예상치 못한 에러 응답:', data)

--- a/src/types/api/user.ts
+++ b/src/types/api/user.ts
@@ -20,15 +20,14 @@ export type CreateProfileImgResponse = ProfileImgResponse
 
 // 프로필사진 삭제
 
-// 내 정보 확인
-export type GetMyProfileResponse = ProfileResponse
-
-// 회원정보 수정
-export interface UpdateMyProfileRequest {
-  newNickname: string
+// 비밀번호 수정
+export interface UpdatePasswordRequest {
   newPassword: string
   newConfirmPassword: string
 }
+
+// 내 정보 확인
+export type GetMyProfileResponse = ProfileResponse
 
 // 회원탈퇴
 export interface DeleteMyProfileRequest {


### PR DESCRIPTION
## 💡 Description
- 비밀번호 변경 페이지 API 연동

## ✨ Changes
- 로그인 여부에 따른 접근 제어
- 기존 "닉네임 + 비밀번호 동시 변경" 에서 "비밀번호만 변경" API로 변경 요청 및 코드 수정
- 비밀번호 변경 기능 추가
- 비밀번호 변경 성공 후 내 프로필 페이지로 리다이렉트