### PR TITLE
[Feature] 닉네임 변경 페이지 API 연동

### DIFF
--- a/src/app/profile/settings/nickname/NicknameForm.tsx
+++ b/src/app/profile/settings/nickname/NicknameForm.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useActionState } from 'react'
+import { updateNicknameAction } from './actions'
+// import { useSession } from 'next-auth/react'
+
+export default function NicknameForm({ nickname }: { nickname: string }) {
+  // const { data: session } = useSession()
+
+  const [state, formAction] = useActionState(updateNicknameAction, {
+    message: '',
+  })
+
+  return (
+    <form action={formAction}>
+      <input
+        className='input input-bordered'
+        placeholder='닉네임을 입력해주세요'
+        name='newNickname'
+        type='text'
+        defaultValue={nickname}
+        required
+      />
+      {state?.message && (
+        <div className='mt-2 text-sm text-red-500'>
+          <p>메세지창</p>
+          <p>{state.message}</p>
+        </div>
+      )}
+      <button className='btn' type='submit'>
+        닉네임 변경하기
+      </button>
+    </form>
+  )
+}

--- a/src/app/profile/settings/nickname/actions.ts
+++ b/src/app/profile/settings/nickname/actions.ts
@@ -1,0 +1,44 @@
+'use server'
+
+import { auth, update } from '@/auth'
+import { updateNickname } from '@/lib/api/user'
+import { redirect } from 'next/navigation'
+
+export const updateNicknameAction = async (
+  state: { message: string } = { message: '' },
+  formData: FormData
+) => {
+  const session = await auth()
+  if (!session?.user) throw new Error('UNAUTHORIZED')
+  const userId = session.user?.userId
+
+  const newNickname = formData.get('newNickname') as string
+  let updatedNickname
+  try {
+    updatedNickname = (
+      await updateNickname(session.accessToken, {
+        newNickname,
+      })
+    ).updatedNickname
+  } catch (error) {
+    const errorCode = (error as Error).message
+    switch (errorCode) {
+      case 'ALREADY_EXIST_NICKNAME':
+        return { ...state, message: '중복 닉네임 입니다' }
+      case 'UNEXPECTED_ERROR':
+        throw new Error('UNEXPECTED_ERROR')
+      // 코드 오류나 프레임워크 내부 예외 등 완전히 예상치 못한 예외 (ex. NEXT_REDIRECT, CallbackRouteError, ReferenceError 등)
+      default:
+        console.error(error)
+        // TODO: error.tsx 제대로 구현 후 error도 넘겨주게 변경
+        throw new Error('UNHANDLED_ERROR')
+    }
+  }
+  // 서버 사이드에서 세션 업데이트
+  await update({
+    user: {
+      nickname: updatedNickname,
+    },
+  })
+  redirect(`/profile/${userId}`)
+}

--- a/src/app/profile/settings/nickname/page.tsx
+++ b/src/app/profile/settings/nickname/page.tsx
@@ -1,0 +1,15 @@
+import { auth } from '@/auth'
+import NicknameForm from './NicknameForm'
+
+export default async function SettingsNicknamePage() {
+  const session = await auth()
+  if (!session?.user) throw new Error('UNAUTHORIZED')
+  const nickname = session?.user?.nickname
+
+  return (
+    <>
+      <h2>닉네임 설정 페이지</h2>
+      <NicknameForm nickname={nickname} />
+    </>
+  )
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,7 +3,13 @@ import Credentials from 'next-auth/providers/credentials'
 import { login } from './lib/api/user'
 import { LoginRequest } from './types/api/user'
 
-export const { handlers, signIn, signOut, auth } = NextAuth({
+export const {
+  handlers,
+  signIn,
+  signOut,
+  auth,
+  unstable_update: update,
+} = NextAuth({
   providers: [
     Credentials({
       authorize: async (credentials) => {
@@ -38,7 +44,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     signIn: '/login',
   },
   callbacks: {
-    async jwt({ token, user }) {
+    async jwt({ token, user, trigger, session }) {
       if (user) {
         token.userId = user.userId
         token.email = user.email!
@@ -46,6 +52,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         token.profileImageUrl = user.profileImageUrl
         token.role = user.role
         token.accessToken = user.accessToken
+      }
+      if (trigger === 'update' && session) {
+        token.nickname = session.user.nickname
       }
       return token
     },

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -13,6 +13,8 @@ import {
   RefreshAccessTokenResponse,
   RegisterRequest,
   UpdateIntroRequest,
+  UpdateNicknameRequest,
+  UpdateNicknameResponse,
   UpdatePasswordRequest,
   UpdateProfileImgRequest,
   UpdateProfileImgResponse,
@@ -58,6 +60,19 @@ export async function deleteProfileImg(token: string): Promise<null> {
 // 비밀번호 수정
 export async function updatePassword(token: string, body: UpdatePasswordRequest): Promise<null> {
   return apiClient<null, UpdatePasswordRequest>(`/users/me/password`, {
+    method: 'PUT',
+    body,
+    withAuth: true,
+    token,
+  })
+}
+
+// 닉네임 수정
+export async function updateNickname(
+  token: string,
+  body: UpdateNicknameRequest
+): Promise<UpdateNicknameResponse> {
+  return apiClient<UpdateNicknameResponse, UpdateNicknameRequest>(`/users/me/nickname`, {
     method: 'PUT',
     body,
     withAuth: true,

--- a/src/types/api/user.ts
+++ b/src/types/api/user.ts
@@ -26,6 +26,15 @@ export interface UpdatePasswordRequest {
   newConfirmPassword: string
 }
 
+// 닉네임 수정
+export interface UpdateNicknameRequest {
+  newNickname: string
+}
+
+export interface UpdateNicknameResponse {
+  updatedNickname: string
+}
+
 // 내 정보 확인
 export type GetMyProfileResponse = ProfileResponse
 


### PR DESCRIPTION
## 💡 Description
- 닉네임 변경 페이지 API 연동

## ✨ Changes
- 로그인 여부에 따른 접근 제어
- 닉네임 변경 기능 추가
- 닉네임 변경 성공 후 세션 업데이트 및 내 프로필 페이지로 리다이렉트
  - `Auth.js`의 `jwt`콜백에서 닉네임 업데이트 로직 추가