### PR TITLE
[Feature] 프로필 페이지 프로필 사진 변경 기능 추가

### DIFF
--- a/src/app/profile/[id]/ProfileImageForm.tsx
+++ b/src/app/profile/[id]/ProfileImageForm.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import Image from 'next/image'
+import { ChangeEvent, useActionState, useState } from 'react'
+import { deleteProfileImgAction, updateProfileImgAction } from './actions'
+
+export default function ProfileImageForm({ profileImageUrl }: { profileImageUrl: string }) {
+  const [currentImage, setCurrentImage] = useState(profileImageUrl)
+
+  const [updateState, updateAction] = useActionState(updateProfileImgAction, {
+    message: '',
+  })
+
+  const [deleteState, deleteAction] = useActionState(deleteProfileImgAction, {
+    message: '',
+  })
+
+  const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files?.[0]) return
+    const file = e.target.files[0]
+    setCurrentImage(URL.createObjectURL(file))
+  }
+
+  return (
+    <div>
+      <Image src={currentImage} alt='프로필 사진' width={100} height={100} />
+      <form action={updateAction}>
+        <input type='file' name='file' accept='image/*' required onChange={handleImageChange} />
+        <button className='btn btn-primary'>수정</button>
+      </form>
+      <form action={deleteAction}>
+        <button className='btn btn-secondary' type='submit'>
+          삭제
+        </button>
+      </form>
+      {(updateState.message || deleteState.message) && (
+        <p className='text-sm text-gray-500'>{updateState.message || deleteState.message}</p>
+      )}
+    </div>
+  )
+}

--- a/src/app/profile/[id]/actions.ts
+++ b/src/app/profile/[id]/actions.ts
@@ -1,8 +1,73 @@
 'use server'
 
-import { auth, signOut } from '@/auth'
-import { logout, updateIntro } from '@/lib/api/user'
+import { auth, signOut, update } from '@/auth'
+import { deleteProfileImg, logout, updateIntro, updateProfileImg } from '@/lib/api/user'
 import { redirect } from 'next/navigation'
+
+export const updateProfileImgAction = async (
+  state: { message: string } = { message: '' },
+  formData: FormData
+) => {
+  const session = await auth()
+  if (!session?.user) throw new Error('UNAUTHORIZED')
+
+  try {
+    const { profileImageUrl } = await updateProfileImg(session.accessToken, formData)
+    await update({
+      user: {
+        profileImageUrl,
+      },
+    })
+  } catch (error) {
+    const errorCode = (error as Error).message
+    switch (errorCode) {
+      case 'IMAGE_FILE_ONLY':
+        return { ...state, message: '이미지 파일만 업로드 가능합니다.' }
+      case 'FILE_SIZE_EXCEEDED':
+        return { ...state, message: '파일 크기는 5MB를 초과할 수 없습니다' }
+      case 'FILE_NOT_FOUND':
+        return { ...state, message: '파일을 업로드 해주세요.' }
+      case 'FILE_UPLOAD_FAILED':
+        return { ...state, message: '파일 업로드 중 문제가 발생했습니다' }
+      case 'UNEXPECTED_ERROR':
+        throw new Error('UNEXPECTED_ERROR')
+      // 코드 오류나 프레임워크 내부 예외 등 완전히 예상치 못한 예외 (ex. NEXT_REDIRECT, CallbackRouteError, ReferenceError 등)
+      default:
+        console.error(error)
+        // TODO: error.tsx 제대로 구현 후 error도 넘겨주게 변경
+        throw new Error('UNHANDLED_ERROR')
+    }
+  }
+  redirect(`/profile/${session.user.userId}`)
+}
+
+export const deleteProfileImgAction = async (state: { message: string } = { message: '' }) => {
+  const session = await auth()
+  if (!session?.user) throw new Error('UNAUTHORIZED')
+
+  try {
+    const { profileImageUrl } = await deleteProfileImg(session.accessToken)
+    await update({
+      user: {
+        profileImageUrl,
+      },
+    })
+  } catch (error) {
+    const errorCode = (error as Error).message
+    switch (errorCode) {
+      case 'FILE_DELETE_FAILED':
+        return { ...state, message: '파일 삭제 중 문제가 발생했습니다' }
+      case 'UNEXPECTED_ERROR':
+        throw new Error('UNEXPECTED_ERROR')
+      // 코드 오류나 프레임워크 내부 예외 등 완전히 예상치 못한 예외 (ex. NEXT_REDIRECT, CallbackRouteError, ReferenceError 등)
+      default:
+        console.error(error)
+        // TODO: error.tsx 제대로 구현 후 error도 넘겨주게 변경
+        throw new Error('UNHANDLED_ERROR')
+    }
+  }
+  redirect(`/profile/${session.user.userId}`)
+}
 
 export const updateIntroAction = async (
   state: { message: string; intro: string } = { message: '', intro: '' },

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -3,10 +3,10 @@ export const dynamic = 'force-dynamic'
 import { auth } from '@/auth'
 import { signOutWithForm } from './actions'
 import { getMyProfile, getUserProfile } from '@/lib/api/user'
-import Image from 'next/image'
 import { Rating } from '@/types/api/user'
 import Link from 'next/link'
 import IntroForm from './IntroForm'
+import ProfileImageForm from './ProfileImageForm'
 
 export default async function ProfilePage({ params }: { params: Promise<{ id: string }> }) {
   const session = await auth()
@@ -22,12 +22,15 @@ export default async function ProfilePage({ params }: { params: Promise<{ id: st
   } else {
     profile = await getUserProfile(session?.accessToken, id)
   }
-  console.log(profile)
+
+  console.log('api응답 유저 정보', profile)
+  console.log('서버 세션 유저 정보', session.user)
+
   return (
     <>
       <section>
         <h2>{isCurrentUser ? '내 프로필' : '다른 사람 프로필'}</h2>
-        <Image src={`${profile.profileImageUrl}`} alt='프로필 사진' width={100} height={100} />
+        <ProfileImageForm profileImageUrl={profile.profileImageUrl} />
         <p>닉네임: {profile.nickname}</p>
         <p>이메일: {profile.email}</p>
         <IntroForm isCurrentUser={isCurrentUser} oneLineIntro={profile.oneLineIntro ?? ''} />

--- a/src/app/profile/settings/profile-image/page.tsx
+++ b/src/app/profile/settings/profile-image/page.tsx
@@ -1,3 +1,0 @@
-export default function SettingProfileImagePage() {
-  return <div>프로필 사진 설정 페이지</div>
-}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -53,8 +53,14 @@ export const {
         token.role = user.role
         token.accessToken = user.accessToken
       }
+
       if (trigger === 'update' && session) {
-        token.nickname = session.user.nickname
+        if (session.user.nickname) {
+          token.nickname = session.user.nickname
+        }
+        if (session.user.profileImageUrl) {
+          token.profileImageUrl = session.user.profileImageUrl
+        }
       }
       return token
     },

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -1,7 +1,6 @@
 import {
-  CreateProfileImgRequest,
-  CreateProfileImgResponse,
   DeleteMyProfileRequest,
+  DeleteProfileImgResponse,
   GetMyProfileResponse,
   GetUserCommentsParams,
   GetUserCommentsResponse,
@@ -23,35 +22,23 @@ import {
 import { apiClient } from '../apiClient'
 import { toQueryString } from '../utils/query'
 
-// 프로필사진 수정
+// 프로필사진 등록/수정
 export async function updateProfileImg(
   token: string,
-  body: UpdateProfileImgRequest
+  formData: UpdateProfileImgRequest
 ): Promise<UpdateProfileImgResponse> {
   return apiClient<UpdateProfileImgResponse, UpdateProfileImgRequest>(`/users/profile-image`, {
     method: 'PUT',
-    body,
-    withAuth: true,
-    token,
-  })
-}
-
-// 프로필사진 등록
-export async function createProfileImg(
-  token: string,
-  body: CreateProfileImgRequest
-): Promise<CreateProfileImgResponse> {
-  return apiClient<CreateProfileImgResponse, CreateProfileImgRequest>(`/users/profile-image`, {
-    method: 'POST',
-    body,
+    body: formData,
+    isFormData: true,
     withAuth: true,
     token,
   })
 }
 
 // 프로필사진 삭제
-export async function deleteProfileImg(token: string): Promise<null> {
-  return apiClient<null>(`/users/profile-image`, {
+export async function deleteProfileImg(token: string): Promise<DeleteProfileImgResponse> {
+  return apiClient<DeleteProfileImgResponse>(`/users/profile-image`, {
     method: 'DELETE',
     withAuth: true,
     token,

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -5,6 +5,7 @@ type ApiFetchOptions<B = undefined> = {
   withAuth?: boolean
   token?: string | null
   cache?: RequestCache
+  isFormData?: boolean
 }
 
 export async function apiClient<T, B = undefined>(
@@ -16,12 +17,13 @@ export async function apiClient<T, B = undefined>(
     withAuth = false,
     token,
     cache = 'no-store',
+    isFormData = false,
   }: ApiFetchOptions<B> = {}
 ): Promise<T> {
   const fullUrl = `${process.env.NEXT_PUBLIC_API_URL}${path}`
 
   const finalHeaders: Record<string, string> = {
-    'Content-Type': 'application/json',
+    ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
     ...headers,
   }
 
@@ -32,7 +34,7 @@ export async function apiClient<T, B = undefined>(
   const fetchOptions: RequestInit = {
     method,
     headers: finalHeaders,
-    body: body ? JSON.stringify(body) : undefined,
+    body: isFormData ? (body as BodyInit) : body ? JSON.stringify(body) : undefined,
     cache,
   }
 

--- a/src/types/api/common.ts
+++ b/src/types/api/common.ts
@@ -74,5 +74,6 @@ export interface Comment {
   createdAt: string
   updatedAt: string
 }
+export type ImgRequest = FormData
 
 export type SortDirection = 'asc' | 'desc'

--- a/src/types/api/user.ts
+++ b/src/types/api/user.ts
@@ -3,6 +3,7 @@ import {
   CertificationRejectionReason,
   CertificationStatus,
   Comment,
+  ImgRequest,
   PaginatedResponse,
   Review,
   SortDirection,
@@ -10,15 +11,12 @@ import {
 
 // API 타입
 
-// 프로필사진 수정
-export type UpdateProfileImgRequest = ProfileImgRequest
+// 프로필사진 등록/수정
+export type UpdateProfileImgRequest = ImgRequest
 export type UpdateProfileImgResponse = ProfileImgResponse
 
-// 프로필사진 등록
-export type CreateProfileImgRequest = ProfileImgRequest
-export type CreateProfileImgResponse = ProfileImgResponse
-
 // 프로필사진 삭제
+export type DeleteProfileImgResponse = ProfileImgResponse
 
 // 비밀번호 수정
 export interface UpdatePasswordRequest {
@@ -110,9 +108,6 @@ export interface ProfileResponse {
 
 export type Rating = '0.5' | '1.0' | '1.5' | '2.0' | '2.5' | '3.0' | '3.5' | '4.0' | '4.5' | '5.0'
 
-export interface ProfileImgRequest {
-  file: string
-}
 export interface ProfileImgResponse {
   profileImageUrl: string
 }


### PR DESCRIPTION
## 💡 Description
- 프로필 사진 변경 페이지 대신 프로필 페이지 내에서 인라인 편집으로 변경

## ✨ Changes
- 기존 프로필 사진 변경 라우트 제거
- 프로필 페이지 내 프로필 사진 변경 및 삭제 기능 추가
- 프로필 사진 수정/등록 API가 통합됨에 따라 코드 수정
- 프로필 사진 삭제 시 기본 프로필 이미지가 응답되도록 API 변경됨에 따라 코드 수정
- 프로필 사진 변경 성공 시 세션 정보 업데이트
  - `auth.js`의 `jwt` 콜백에서 프로필 사진 업데이트 로직 추가