### PR TITLE
[Feature] 시청 인증 관리 페이지 API 연동

### DIFF
--- a/src/app/admin/watch-approval/CertificationItem.tsx
+++ b/src/app/admin/watch-approval/CertificationItem.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { Certification } from '@/types/api/certification'
+import Image from 'next/image'
+import { updateCertificationStatusAction } from './actions'
+import { useActionState } from 'react'
+
+export default function CertificationItem({ certification }: { certification: Certification }) {
+  const [state, formAction, isPending] = useActionState(updateCertificationStatusAction, {
+    certification,
+    message: '',
+  })
+
+  return (
+    <form action={formAction}>
+      <div className='rounded-lg border p-4 shadow-md'>
+        <Image
+          src={state.certification.certificationUrl}
+          alt='Certification'
+          width={100}
+          height={100}
+          className='mb-4 h-48 w-full object-cover'
+        />
+        <p>
+          <strong>User ID:</strong> {state.certification.userId}
+        </p>
+        <p>
+          <strong>Status:</strong> {state.certification.status}
+        </p>
+        {state.certification.rejectionReason && <p>{state.certification.rejectionReason}</p>}
+        <p>
+          <strong>Created At:</strong> {state.certification.createdAt}
+        </p>
+        {state.certification.status === 'PENDING' && (
+          <div className='mt-4 flex flex-col gap-2'>
+            <button
+              className='btn btn-success'
+              name='approve'
+              value='true'
+              type='submit'
+              disabled={isPending}
+            >
+              {isPending ? '처리 중...' : '승인'}
+            </button>
+            <select
+              className='select select-bordered'
+              name='rejectionReason'
+              defaultValue='UNIDENTIFIABLE_IMAGE'
+            >
+              <option value='UNIDENTIFIABLE_IMAGE'>식별 불가 이미지</option>
+              <option value='WRONG_IMAGE'>잘못된 이미지</option>
+              <option value='OTHER_MOVIE_IMAGE'>다른 영화 이미지</option>
+            </select>
+            <button
+              className='btn btn-error'
+              name='approve'
+              value='false'
+              type='submit'
+              disabled={isPending}
+            >
+              {isPending ? '처리 중...' : '거절'}
+            </button>
+          </div>
+        )}
+        {state.message && <p className='text-sm'>{state.message}</p>}
+      </div>
+    </form>
+  )
+}

--- a/src/app/admin/watch-approval/actions.ts
+++ b/src/app/admin/watch-approval/actions.ts
@@ -1,0 +1,44 @@
+'use server'
+
+import { auth } from '@/auth'
+import { updateCertificationStatus } from '@/lib/api/certification'
+import { Certification } from '@/types/api/certification'
+import { CertificationRejectionReason } from '@/types/api/common'
+
+export const updateCertificationStatusAction = async (
+  state: {
+    certification: Certification
+    message: string
+  },
+  formData: FormData
+) => {
+  const session = await auth()
+  if (!session) throw new Error('UNAUTHORIZED')
+
+  const approve = formData.get('approve') === 'true'
+  const rejectionReason = formData.get('rejectionReason') as CertificationRejectionReason
+
+  const payload = approve ? { approve } : { approve, rejectionReason }
+
+  try {
+    const certification = await updateCertificationStatus(
+      state.certification.id.toString(),
+      session.accessToken,
+      payload
+    )
+    return { ...state, certification, message: '처리 성공' }
+  } catch (error) {
+    const errorCode = (error as Error).message
+    switch (errorCode) {
+      case 'CERTIFICATION_NOT_FOUND':
+        return { ...state, message: '인증요청이 존재하지 않습니다.' }
+      case 'UNEXPECTED_ERROR':
+        throw new Error('UNEXPECTED_ERROR')
+      // 코드 오류나 프레임워크 내부 예외 등 완전히 예상치 못한 예외 (ex. NEXT_REDIRECT, CallbackRouteError, ReferenceError 등)
+      default:
+        console.error(error)
+        // TODO: error.tsx 제대로 구현 후 error도 넘겨주게 변경
+        throw new Error('UNHANDLED_ERROR')
+    }
+  }
+}

--- a/src/app/admin/watch-approval/page.tsx
+++ b/src/app/admin/watch-approval/page.tsx
@@ -1,3 +1,19 @@
-export default function AdminWatchApprovalPage() {
-  return <div>관리자 인증 관리 페이지</div>
+import { auth } from '@/auth'
+import { getCertifications } from '@/lib/api/certification'
+import CertificationItem from './CertificationItem'
+
+export default async function AdminWatchApprovalPage() {
+  const session = await auth()
+  if (!session) throw new Error('UNAUTHORIZED')
+  const certifications = await getCertifications(session.accessToken)
+
+  // TODO: 페이지네이션 무한스크롤, 필터링
+  return (
+    <>
+      <h2>관리자 인증 관리 페이지</h2>
+      {certifications.content.map((certification) => (
+        <CertificationItem key={certification.id} certification={certification} />
+      ))}
+    </>
+  )
 }

--- a/src/lib/api/certification.ts
+++ b/src/lib/api/certification.ts
@@ -7,6 +7,7 @@ import {
   UpdateCertificationRequest,
   UpdateCertificationResponse,
   UpdateCertificationStatusRequest,
+  UpdateCertificationStatusResponse,
 } from '@/types/api/certification'
 import { apiClient } from '../apiClient'
 import { toQueryString } from '../utils/query'
@@ -48,11 +49,11 @@ export async function deleteCertification(token: string) {
 
 // 인증 승인/거절
 export async function updateCertificationStatus(
-  id: string | number,
+  id: string,
   token: string,
   body: UpdateCertificationStatusRequest
-): Promise<null> {
-  return apiClient<null, UpdateCertificationStatusRequest>(
+): Promise<UpdateCertificationStatusResponse> {
+  return apiClient<UpdateCertificationStatusResponse, UpdateCertificationStatusRequest>(
     `/certifications/admin/proceeding/${id}`,
     {
       method: 'POST',

--- a/src/types/api/certification.ts
+++ b/src/types/api/certification.ts
@@ -27,6 +27,8 @@ export interface UpdateCertificationStatusRequest {
   rejectionReason?: CertificationRejectionReason
 }
 
+export type UpdateCertificationStatusResponse = Certification
+
 // 인증샷 상태 확인
 export type GetCertificationResponse = Certification
 

--- a/src/types/api/common.ts
+++ b/src/types/api/common.ts
@@ -15,30 +15,13 @@ export type CertificationRejectionReason =
   | 'WRONG_IMAGE'
   | 'UNIDENTIFIABLE_IMAGE'
 
-export interface PageableInfo {
-  offset: number
-  sort: SortInfo
-  pageSize: number
-  paged: boolean
-  pageNumber: number
-  unpaged: boolean
-}
-
-export interface SortInfo {
-  empty: boolean
-  sorted: boolean
-  unsorted: boolean
-}
-
 export interface PaginatedResponse<T> {
-  totalElements: number
-  totalPages: number
-  size: number
   content: T[]
   number: number
-  sort: SortInfo
+  size: number
+  totalPages: number
+  totalElements: number
   numberOfElements: number
-  pageable: PageableInfo
   first: boolean
   last: boolean
   empty: boolean


### PR DESCRIPTION
## 💡 Description
- 시청 인증 관리 페이지 API 연동

## ✨ Changes
- 사용자가 올린 시청 인증 목록 표시
- 시청 인증 상태 변경 기능 추가 (승인 / 거절 + 거절 사유)
- 시청 인증 상태 변경 API 응답 변경 요청에 및 코드 수정
  - 변경된 인증 정보가 응답으로 오도록 변경됨
  - 변경 후 즉시 화면에 반영