### PR TITLE
[Feature] 시청 인증 제출 페이지 API 연동

### DIFF
--- a/src/app/profile/settings/page.tsx
+++ b/src/app/profile/settings/page.tsx
@@ -1,3 +1,0 @@
-export default function ProfileSettingsPage() {
-  return <div>프로필 설정 페이지</div>
-}

--- a/src/app/profile/watch-verification/ImgForm.tsx
+++ b/src/app/profile/watch-verification/ImgForm.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import Image from 'next/image'
+import { ChangeEvent, useActionState, useState } from 'react'
+import {
+  createCertificationAction,
+  updateCertificationAction,
+  deleteCertificationAction,
+} from './actions'
+import { CertificationStatus } from '@/types/api/common'
+
+export default function ImgForm({
+  status,
+  certificationUrl,
+}: {
+  status: CertificationStatus
+  certificationUrl: string | null
+}) {
+  const [currentImage, setCurrentImage] = useState(certificationUrl)
+
+  const [createState, createAction] = useActionState(createCertificationAction, {
+    message: '',
+  })
+
+  const [updateState, updateAction] = useActionState(updateCertificationAction, {
+    message: '',
+  })
+
+  const [deleteState, deleteAction] = useActionState(deleteCertificationAction, {
+    message: '',
+  })
+
+  const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files?.[0]) return
+    const file = e.target.files[0]
+    setCurrentImage(URL.createObjectURL(file))
+  }
+
+  return (
+    <div>
+      {currentImage ? (
+        <Image src={currentImage} alt='프로필 사진' width={100} height={100} />
+      ) : (
+        <div>이미지가 없습니다</div>
+      )}
+
+      <button
+        className='btn'
+        onClick={() => setCurrentImage(null)}
+        type='button'
+        disabled={!currentImage}
+      >
+        취소
+      </button>
+
+      <form action={status === 'NONE' ? createAction : updateAction}>
+        <input type='file' name='file' accept='image/*' required onChange={handleImageChange} />
+        <button className='btn btn-primary'>{status === 'NONE' ? '등록' : '수정'}</button>
+      </form>
+
+      {status === 'PENDING' && (
+        <form action={deleteAction}>
+          <button className='btn btn-secondary' type='submit'>
+            삭제
+          </button>
+        </form>
+      )}
+
+      {(createState.message || updateState.message || deleteState.message) && (
+        <p className='text-sm text-gray-500'>
+          {createState.message || updateState.message || deleteState.message}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/app/profile/watch-verification/actions.ts
+++ b/src/app/profile/watch-verification/actions.ts
@@ -1,0 +1,110 @@
+'use server'
+
+import { auth } from '@/auth'
+import {
+  createCertification,
+  deleteCertification,
+  updateCertification,
+} from '@/lib/api/certification'
+import { redirect } from 'next/navigation'
+
+export const createCertificationAction = async (
+  state: { message: string } = { message: '' },
+  formData: FormData
+) => {
+  const session = await auth()
+  if (!session?.user) throw new Error('UNAUTHORIZED')
+
+  try {
+    await createCertification(session.accessToken, formData)
+  } catch (error) {
+    const errorCode = (error as Error).message
+    switch (errorCode) {
+      case 'ALREADY_APPROVED':
+        return { ...state, message: '이미 승인되었습니다.' }
+      case 'IMAGE_FILE_ONLY':
+        return { ...state, message: '이미지 파일만 업로드 가능합니다.' }
+      case 'FILE_SIZE_EXCEEDED':
+        return { ...state, message: '파일 크기는 5MB를 초과할 수 없습니다' }
+      case 'FILE_NOT_FOUND':
+        return { ...state, message: '파일을 업로드 해주세요.' }
+      case 'FILE_UPLOAD_FAILED':
+        return { ...state, message: '파일 업로드 중 문제가 발생했습니다' }
+      case 'CERTIFICATION_NOT_ALLOWED_ON_SUNDAY':
+        return { ...state, message: "인증 가능 기간은 '월-토'입니다." }
+      case 'UNEXPECTED_ERROR':
+        throw new Error('UNEXPECTED_ERROR')
+      // 코드 오류나 프레임워크 내부 예외 등 완전히 예상치 못한 예외 (ex. NEXT_REDIRECT, CallbackRouteError, ReferenceError 등)
+      default:
+        console.error(error)
+        // TODO: error.tsx 제대로 구현 후 error도 넘겨주게 변경
+        throw new Error('UNHANDLED_ERROR')
+    }
+  }
+  redirect('/profile/watch-verification')
+}
+
+export const updateCertificationAction = async (
+  state: { message: string } = { message: '' },
+  formData: FormData
+) => {
+  const session = await auth()
+  if (!session?.user) throw new Error('UNAUTHORIZED')
+
+  try {
+    await updateCertification(session.accessToken, formData)
+  } catch (error) {
+    const errorCode = (error as Error).message
+    switch (errorCode) {
+      case 'CERTIFICATION_NOT_FOUND':
+        return { ...state, message: '인증요청이 존재하지 않습니다.' }
+      case 'ALREADY_APPROVED':
+        return { ...state, message: '이미 승인되었습니다.' }
+      case 'IMAGE_FILE_ONLY':
+        return { ...state, message: '이미지 파일만 업로드 가능합니다.' }
+      case 'FILE_SIZE_EXCEEDED':
+        return { ...state, message: '파일 크기는 5MB를 초과할 수 없습니다' }
+      case 'FILE_NOT_FOUND':
+        return { ...state, message: '파일을 업로드 해주세요.' }
+      case 'FILE_UPLOAD_FAILED':
+        return { ...state, message: '파일 업로드 중 문제가 발생했습니다' }
+      case 'CERTIFICATION_NOT_ALLOWED_ON_SUNDAY':
+        return { ...state, message: "인증 가능 기간은 '월-토'입니다." }
+      case 'UNEXPECTED_ERROR':
+        throw new Error('UNEXPECTED_ERROR')
+      // 코드 오류나 프레임워크 내부 예외 등 완전히 예상치 못한 예외 (ex. NEXT_REDIRECT, CallbackRouteError, ReferenceError 등)
+      default:
+        console.error(error)
+        // TODO: error.tsx 제대로 구현 후 error도 넘겨주게 변경
+        throw new Error('UNHANDLED_ERROR')
+    }
+  }
+  redirect('/profile/watch-verification')
+}
+
+export const deleteCertificationAction = async (state: { message: string } = { message: '' }) => {
+  const session = await auth()
+  if (!session?.user) throw new Error('UNAUTHORIZED')
+
+  try {
+    await deleteCertification(session.accessToken)
+  } catch (error) {
+    const errorCode = (error as Error).message
+    switch (errorCode) {
+      case 'CERTIFICATION_NOT_FOUND':
+        return { ...state, message: '인증요청이 존재하지 않습니다.' }
+      case 'ALREADY_APPROVED':
+        return { ...state, message: '이미 승인되었습니다.' }
+      case 'FILE_DELETE_FAILED':
+        return { ...state, message: '파일 삭제 중 문제가 발생했습니다' }
+      case 'UNEXPECTED_ERROR':
+        throw new Error('UNEXPECTED_ERROR')
+      // 코드 오류나 프레임워크 내부 예외 등 완전히 예상치 못한 예외 (ex. NEXT_REDIRECT, CallbackRouteError, ReferenceError 등)
+      default:
+        console.error(error)
+        // TODO: error.tsx 제대로 구현 후 error도 넘겨주게 변경
+        throw new Error('UNHANDLED_ERROR')
+    }
+  }
+  redirect('/profile/watch-verification')
+}

--- a/src/app/profile/watch-verification/page.tsx
+++ b/src/app/profile/watch-verification/page.tsx
@@ -1,3 +1,24 @@
-export default function WatchVerificationPage() {
-  return <div>유저 시청 인증 페이지</div>
+import { auth } from '@/auth'
+import { getCertification } from '@/lib/api/certification'
+import ImgForm from './ImgForm'
+
+export default async function WatchVerificationPage() {
+  const session = await auth()
+  if (!session) throw new Error('UNAUTHORIZED')
+
+  const certification = await getCertification(session.accessToken)
+  console.log(certification)
+  return (
+    <>
+      <h2>유저 시청 인증 페이지</h2>
+      <div>
+        <p>날짜: {certification.createdAt}</p>
+        <p>상태: {certification.status}</p>
+        {certification.rejectionReason && <p>이유: {certification.rejectionReason}</p>}
+      </div>
+      <div>
+        <ImgForm status={certification.status} certificationUrl={certification.certificationUrl} />
+      </div>
+    </>
+  )
 }

--- a/src/lib/api/certification.ts
+++ b/src/lib/api/certification.ts
@@ -14,12 +14,13 @@ import { toQueryString } from '../utils/query'
 
 // 인증샷 수정
 export async function updateCertification(
-  body: UpdateCertificationRequest,
-  token: string
+  token: string,
+  formData: UpdateCertificationRequest
 ): Promise<UpdateCertificationResponse> {
   return apiClient<UpdateCertificationResponse, UpdateCertificationRequest>(`/certifications`, {
     method: 'PUT',
-    body,
+    body: formData,
+    isFormData: true,
     withAuth: true,
     token,
   })
@@ -27,12 +28,13 @@ export async function updateCertification(
 
 // 인증샷 제출
 export async function createCertification(
-  body: CreateCertificationRequest,
-  token: string
+  token: string,
+  formData: CreateCertificationRequest
 ): Promise<CreateCertificationResponse> {
   return apiClient<CreateCertificationResponse, CreateCertificationRequest>(`/certifications`, {
     method: 'POST',
-    body,
+    body: formData,
+    isFormData: true,
     withAuth: true,
     token,
   })

--- a/src/types/api/certification.ts
+++ b/src/types/api/certification.ts
@@ -27,7 +27,7 @@ export interface UpdateCertificationStatusRequest {
 export type UpdateCertificationStatusResponse = Certification
 
 // 인증샷 상태 확인
-export type GetCertificationResponse = Certification
+export type GetCertificationResponse = NullableCertification
 
 // 인증 목록 조회
 export interface GetCertificationsParams {
@@ -48,11 +48,14 @@ export type CertificationPendingResponse = {
   rejectionReason: null
 }
 export interface Certification {
-  id: number | null
-  userId: number | null
-  certificationUrl: string | null
-  status: CertificationStatus | null
-  createdAt: string | null
-  rejectionReason: CertificationRejectionReason | null
+  id: number
+  userId: number
+  certificationUrl: string
+  status: CertificationStatus
+  createdAt: string
+  rejectionReason: CertificationRejectionReason
+}
+export type NullableCertification = {
+  [K in keyof Certification]: Certification[K] | null
 }
 export type SortField = 'id' | 'createdAt' | 'status'

--- a/src/types/api/certification.ts
+++ b/src/types/api/certification.ts
@@ -1,6 +1,7 @@
 import {
   CertificationRejectionReason,
   CertificationStatus,
+  ImgRequest,
   PaginatedResponse,
   SortDirection,
 } from './common'
@@ -8,15 +9,11 @@ import {
 // API 타입
 
 // 인증샷 수정
-export interface UpdateCertificationRequest {
-  file: string
-}
+export type UpdateCertificationRequest = ImgRequest
 export type UpdateCertificationResponse = CertificationPendingResponse
 
 // 인증샷 제출
-export interface CreateCertificationRequest {
-  file: string
-}
+export type CreateCertificationRequest = ImgRequest
 export type CreateCertificationResponse = CertificationPendingResponse
 
 // 인증샷 삭제
@@ -51,11 +48,11 @@ export type CertificationPendingResponse = {
   rejectionReason: null
 }
 export interface Certification {
-  id: number
-  userId: number
-  certificationUrl: string
-  status: CertificationStatus
-  createdAt: string
+  id: number | null
+  userId: number | null
+  certificationUrl: string | null
+  status: CertificationStatus | null
+  createdAt: string | null
   rejectionReason: CertificationRejectionReason | null
 }
 export type SortField = 'id' | 'createdAt' | 'status'

--- a/src/types/api/common.ts
+++ b/src/types/api/common.ts
@@ -8,7 +8,7 @@ export interface BaseUser {
   refreshToken: string
 }
 
-export type CertificationStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | null
+export type CertificationStatus = 'NONE' | 'PENDING' | 'APPROVED' | 'REJECTED' | null
 
 export type CertificationRejectionReason =
   | 'OTHER_MOVIE_IMAGE'


### PR DESCRIPTION
## 💡 Description
- 시청 인증 제출 페이지 API 연동

## ✨ Changes
- 사용자가 올린 시청 인증 표시
- 사용자가 올린 시청 인증 없을때 응답 404에서 200으로 API 변경 요청 및 코드 수정
- 시청 인증 제출, 수정, 삭제 기능 추가