### PR TITLE
[Feature] SSEClient 추가 및 레이아웃 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/postcss": "^4.0.6",
         "clsx": "^2.1.1",
+        "event-source-polyfill": "^1.0.31",
         "lucide-react": "^0.475.0",
         "next": "15.1.7",
         "next-auth": "^5.0.0-beta.25",
@@ -18,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@types/event-source-polyfill": "^1.0.5",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1124,6 +1126,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/event-source-polyfill": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz",
+      "integrity": "sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2728,6 +2737,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tailwindcss/postcss": "^4.0.6",
     "clsx": "^2.1.1",
+    "event-source-polyfill": "^1.0.31",
     "lucide-react": "^0.475.0",
     "next": "15.1.7",
     "next-auth": "^5.0.0-beta.25",
@@ -19,6 +20,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@types/event-source-polyfill": "^1.0.5",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css'
 import TopNav from '@/components/layout/TopNav'
 import BottomNav from '@/components/layout/BottomNav'
 import Providers from '@/providers/providers'
+import SSEClient from '@/components/layout/SSEClient'
 
 export const metadata: Metadata = {
   title: 'Deepdiview',
@@ -17,6 +18,7 @@ export default function RootLayout({
     <html lang='ko'>
       <body>
         <Providers>
+          <SSEClient />
           <div className='mx-auto max-w-[1440px] px-4 sm:px-6 lg:px-8'>
             <header>
               <TopNav />

--- a/src/components/layout/SSEClient.tsx
+++ b/src/components/layout/SSEClient.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { useEffect } from 'react'
+import { EventSourcePolyfill } from 'event-source-polyfill'
+
+export default function SSEClient() {
+  const { data: session } = useSession()
+
+  useEffect(() => {
+    const userId = session?.user?.userId
+    const token = session?.accessToken
+
+    if (!userId || !token) {
+      console.warn('SSE 구독 조건 부족 (userId 또는 token 없음)')
+      return
+    }
+
+    console.log('SSE 구독 시도')
+
+    const eventSource = new EventSourcePolyfill(
+      `${process.env.NEXT_PUBLIC_API_URL}/notifications/subscribe`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'text/event-stream',
+        },
+        heartbeatTimeout: 45000,
+      }
+    )
+
+    // 연결 성공 (connect 이벤트)
+    eventSource.addEventListener('connect', (event) => {
+      const data = (event as MessageEvent).data
+      console.log('SSE 연결 성공', data)
+    })
+
+    // 핑 수신 (ping 이벤트)
+    eventSource.addEventListener('ping', (event) => {
+      const data = (event as MessageEvent).data
+      console.log('핑 수신', data)
+    })
+
+    // 알림 수신
+    eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data)
+
+        switch (data.type) {
+          case 'like':
+            console.log('좋아요 알림:', data.message)
+            break
+          case 'comment':
+            console.log('댓글 알림:', data.message)
+            break
+          case 'certification':
+            console.log('인증 상태 변경 알림:', data.message)
+            break
+          default:
+            console.warn('알 수 없는 타입의 알림:', data)
+        }
+      } catch (error) {
+        console.error('알림 파싱 실패:', error)
+      }
+    }
+
+    // 에러 처리
+    eventSource.onerror = (error) => {
+      console.error('SSE 연결 오류', error)
+    }
+
+    // 언마운트 시 연결 종료
+    return () => {
+      console.log('SSE 구독 종료')
+      eventSource.close()
+    }
+  }, [session])
+
+  return null
+}


### PR DESCRIPTION
## 💡 Description
- 실시간 알림용 SSEClient 추가 및 레이아웃에 적용

## ✨ Changes
- `event-source-polyfill` 라이브러리 추가
- `SSEClient` 컴포넌트 구현 (로그인 상태일 때만 SSE 연결 구독)
- `RootLayout`에 `SSEClient` 주입하여 전역 SSE 구독 처리
- SSE 연결 유지 이슈 대응  
  - 45초 동안 메시지 수신 없을 경우 연결 끊김 현상 발생  
  - 서버에 30초마다 ping 전송하도록 API 변경 요청  
  - 클라이언트 측 ping 이벤트 핸들링 로직 추가

## ✏️ Notes
- 현재는 콘솔 로그로만 동작 확인
- UI 구현은 추후 진행 예정