### PR TITLE
[Feature] SessionProvider 반응형 처리

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import './globals.css'
 import TopNav from '@/components/layout/TopNav'
 import BottomNav from '@/components/layout/BottomNav'
-import Providers from '@/providers/providers'
+import { SessionProvider } from '@/providers/providers'
 import SSEClient from '@/components/layout/SSEClient'
 
 export const metadata: Metadata = {
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang='ko'>
       <body>
-        <Providers>
+        <SessionProvider>
           <SSEClient />
           <div className='mx-auto max-w-[1440px] px-4 sm:px-6 lg:px-8'>
             <header>
@@ -28,7 +28,7 @@ export default function RootLayout({
               <BottomNav />
             </footer>
           </div>
-        </Providers>
+        </SessionProvider>
       </body>
     </html>
   )

--- a/src/app/reviews/[id]/CommentForm.tsx
+++ b/src/app/reviews/[id]/CommentForm.tsx
@@ -2,8 +2,8 @@
 
 import { useActionState, useEffect, useState } from 'react'
 import { createCommentAction, updateCommentAction } from './actions'
-import { useSession } from 'next-auth/react'
 import Link from 'next/link'
+import { useSession } from 'next-auth/react'
 
 export default function CommentForm({
   reviewId,
@@ -17,7 +17,7 @@ export default function CommentForm({
   }
   onCancel: () => void
 }) {
-  const { data: session } = useSession()
+  const session = useSession()
   const isEdit = !!editComment
   const [content, setContent] = useState('')
 

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -4,12 +4,11 @@ import { Bell, Home, KeyRound, NotebookPen, Search, UserRound } from 'lucide-rea
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import clsx from 'clsx'
-import { useSession } from 'next-auth/react'
+import { useSession } from '@/providers/providers'
 
 export default function BottomNav() {
   const pathname = usePathname()
-  // TODO: 바로 세션 변화 알아차리게 구현
-  const { data: session } = useSession()
+  const session = useSession()
 
   return (
     <nav className='dock md:hidden'>

--- a/src/components/layout/SSEClient.tsx
+++ b/src/components/layout/SSEClient.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useSession } from 'next-auth/react'
 import { useEffect } from 'react'
 import { EventSourcePolyfill } from 'event-source-polyfill'
+import { useSession } from '@/providers/providers'
 
 export default function SSEClient() {
-  const { data: session } = useSession()
+  const session = useSession()
 
   useEffect(() => {
     const userId = session?.user?.userId

--- a/src/providers/actions.ts
+++ b/src/providers/actions.ts
@@ -1,0 +1,5 @@
+'use server'
+
+import { auth } from '@/auth'
+
+export { auth as getServerSession }

--- a/src/providers/providers.tsx
+++ b/src/providers/providers.tsx
@@ -1,7 +1,25 @@
 'use client'
 
-import { SessionProvider } from 'next-auth/react'
+import { Session } from 'next-auth'
+import { usePathname } from 'next/navigation'
+import { createContext, useContext, useEffect, useState } from 'react'
+import { getServerSession } from './actions'
 
-export default function Providers({ children }: { children: React.ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>
+const SessionContent = createContext<Session | null>(null)
+
+export function SessionProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const [session, setSession] = useState<Session | null>(null)
+
+  useEffect(() => {
+    getServerSession().then((res) => {
+      setSession(res)
+    })
+  }, [pathname])
+
+  return <SessionContent.Provider value={session}>{children}</SessionContent.Provider>
+}
+
+export function useSession() {
+  return useContext(SessionContent)
 }


### PR DESCRIPTION
## 💡 Description
- 기존 `next-auth/react`의 `SessionProvider` 대신 커스텀 `SessionProvider` 구현
- 페이지 이동 시 세션을 자동으로 갱신할 수 있도록 반응형 처리

## ✨ Changes
- `next-auth/react`의 `SessionProvider` 제거
- `usePathname`, `useEffect`, `useState`, `createContext`를 사용하여 커스텀 세션 컨텍스트 구현
- 경로 변경 시 서버 세션 재조회 후 Context에 반영
- 기존 `useSession()` 훅을 커스텀 훅으로 대체