### PR TITLE
[Feature] 검색 페이지 UI, 레이아웃 여백 구조 개선

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default async function RootLayout({
           <header>
             <TopNav />
           </header>
-          <main className='flex-1 pb-18 md:pb-4'>{children}</main>
+          <main className='flex-1 pb-2 md:pb-4'>{children}</main>
           <BottomNav />
           <Footer />
         </SessionProvider>

--- a/src/app/search/SearchMovieItem.tsx
+++ b/src/app/search/SearchMovieItem.tsx
@@ -1,0 +1,32 @@
+import { Movie } from '@/types/api/movie'
+import clsx from 'clsx'
+import Image from 'next/image'
+import Link from 'next/link'
+import React from 'react'
+
+export default function SearchMovieItem({ movie }: { movie: Movie }) {
+  return (
+    <Link href={`/movies/${movie.id}`}>
+      <div className='flex h-40 gap-4'>
+        <div className='relative aspect-2/3'>
+          <Image
+            src={`https://image.tmdb.org/t/p/w500${movie.poster_path}`}
+            alt='영화 포스터'
+            fill
+            className={clsx('rounded-md', !movie.available && 'grayscale')}
+          />
+        </div>
+        <div className='line-clamp-3 flex w-full flex-col justify-between'>
+          <div className='space-y-0.5'>
+            <p className='text-md font-semibold md:text-lg md:font-bold'>{movie.title}</p>
+            <p className='md:text-md text-sm'>
+              {movie.release_date.slice(0, 4)} · {movie.genre_names.join(' / ')}
+              {movie.runtime && ` · ${movie.runtime}분`}
+            </p>
+          </div>
+          <p className='text-md line-clamp-3 text-justify'>{movie.overview}</p>
+        </div>
+      </div>
+    </Link>
+  )
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,68 +1,103 @@
-import SearchForm from '@/components/form/SearchForm'
+import SearchHeader from '@/components/layout/MobileHeader/SearchHeader'
 import { getSearchedMovies } from '@/lib/api/movie'
-import Image from 'next/image'
+import SearchMovieItem from './SearchMovieItem'
 import Link from 'next/link'
+import clsx from 'clsx'
 
 export default async function SearchPage({
   searchParams,
 }: {
-  searchParams: Promise<{ title?: string }>
+  searchParams: Promise<{ title?: string; page?: string }>
 }) {
-  const { title = '' } = await searchParams
+  const { title = '', page = '1' } = await searchParams
+  const trimmedTitle = title.trim()
+  const pageNumber = Number(page)
 
-  // 검색어가 없는 경우
-  if (!title.trim()) {
-    return (
-      <>
-        <div className='md:hidden'>
-          <SearchForm />
-        </div>
-        <p>검색어를 입력해주세요.</p>
-      </>
-    )
-  }
-
-  // 검색 결과가 없는 경우
-  let movies = []
-  try {
-    movies = (await getSearchedMovies({ title, page: 0 })).content
-  } catch (error) {
-    const errorCode = (error as Error).message
-    if (errorCode === 'KEYWORD_NOT_FOUND') {
-      return (
-        <>
-          <div className='md:hidden'>
-            <SearchForm />
-          </div>
-          <p>{title}에 대한 검색 결과가 없습니다.</p>
-        </>
-      )
-    } else {
-      throw error
-    }
-  }
+  const {
+    content: movies,
+    totalElements,
+    totalPages,
+  } = await getSearchedMovies({ title: trimmedTitle, page: pageNumber - 1 })
 
   return (
     <>
-      <div className='md:hidden'>
-        <SearchForm />
+      <SearchHeader />
+      <div className='container-wrapper'>
+        {!trimmedTitle ? (
+          <p className='py-4'>검색어를 입력해 주세요.</p>
+        ) : movies.length === 0 ? (
+          <p className='py-4'>
+            &quot;<span className='font-bold'>{trimmedTitle}</span>&quot;에 대한 검색 결과가
+            없습니다.
+          </p>
+        ) : (
+          <>
+            <p className='py-4'>
+              &quot;<span className='font-bold'>{trimmedTitle}</span>&quot;의 검색 결과 (
+              {totalElements})
+            </p>
+            <ul className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+              {movies.map((movie) => (
+                <li key={movie.id}>
+                  <SearchMovieItem movie={movie} />
+                  <hr className='mt-4 text-gray-700' />
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+        {/* 페이지네이션 */}
+        {totalPages > 1 && (
+          <div className='join mt-2 w-full justify-center md:mt-4'>
+            {pageNumber > 3 && (
+              <>
+                <Link
+                  className='join-item btn btn-sm md:btn-md'
+                  key={1}
+                  href={`/search?title=${encodeURIComponent(trimmedTitle)}&page=1`}
+                >
+                  1
+                </Link>
+                {pageNumber > 4 && (
+                  <button className='join-item btn btn-sm md:btn-md btn-disabled'>···</button>
+                )}
+              </>
+            )}
+            <>
+              {Array.from({ length: 5 }).map((_, i) => {
+                const targetPage = pageNumber - 2 + i
+                if (targetPage < 1 || targetPage > totalPages) return null
+                return (
+                  <Link
+                    className={clsx(
+                      'join-item btn btn-sm md:btn-md',
+                      targetPage === pageNumber && 'bg-primary pointer-events-none'
+                    )}
+                    key={targetPage}
+                    href={`/search?title=${encodeURIComponent(trimmedTitle)}&page=${targetPage}`}
+                  >
+                    {targetPage}
+                  </Link>
+                )
+              })}
+              {pageNumber + 2 < totalPages && (
+                <>
+                  {pageNumber + 3 < totalPages && (
+                    <button className='join-item btn btn-sm btn-disabled md:btn-md'>···</button>
+                  )}
+                  <Link
+                    className='join-item btn btn-sm md:btn-md'
+                    key={totalPages}
+                    href={`/search?title=${encodeURIComponent(trimmedTitle)}&page=${totalPages}`}
+                  >
+                    {totalPages}
+                  </Link>
+                </>
+              )}
+            </>
+          </div>
+        )}
       </div>
-      <h2>{title}에 대한 검색 결과</h2>
-      <ul>
-        {movies.map((movie) => (
-          <li key={movie.id}>
-            <Link href={`/movies/${movie.id}`}>
-              <p>{movie.title}</p>
-              <Image
-                src={`https://image.tmdb.org/t/p/original${movie.poster_path}`}
-                alt='영화 포스터'
-                width={100}
-                height={150}
-              />
-            </Link>
-          </li>
-        ))}
-      </ul>
     </>
   )
 }

--- a/src/components/form/SearchForm.tsx
+++ b/src/components/form/SearchForm.tsx
@@ -14,6 +14,8 @@ export default function SearchForm() {
     if (pathname === '/search') {
       const titleFromUrl = searchParams.get('title') ?? ''
       setQuery(titleFromUrl)
+    } else {
+      setQuery('')
     }
   }, [pathname, searchParams])
 
@@ -23,8 +25,8 @@ export default function SearchForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit}>
-      <label className='input focus-within:border-primary focus-within:outline-none'>
+    <form onSubmit={handleSubmit} className='w-full'>
+      <label className='input focus-within:border-primary w-full bg-transparent focus-within:outline-none'>
         <Search className='h-[1em] opacity-50' />
         <input
           type='search'

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -5,42 +5,60 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import clsx from 'clsx'
 import { useSession } from '@/providers/providers'
+import { useEffect, useState } from 'react'
 
 export default function BottomNav() {
   const pathname = usePathname()
   const session = useSession()
+  const [isKeyboardVisible, setIsKeyboardVisible] = useState(false)
+
+  useEffect(() => {
+    const threshold = 150 // 높이 차이가 이 이상이면 키보드가 올라왔다고 판단
+    const initialHeight = window.innerHeight
+
+    const handleResize = () => {
+      const heightDiff = initialHeight - window.innerHeight
+      setIsKeyboardVisible(heightDiff > threshold)
+    }
+
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
 
   return (
-    <nav className='dock z-50 md:hidden'>
-      <Link href='/' className={clsx({ 'dock-active text-primary': pathname === '/' })}>
-        <Home />
-      </Link>
-      <Link
-        href='/search'
-        className={clsx({ 'dock-active text-primary': pathname.startsWith('/search') })}
-      >
-        <Search />
-      </Link>
-      <Link
-        href='/board'
-        className={clsx({ 'dock-active text-primary': pathname.startsWith('/board') })}
-      >
-        <NotebookPen />
-      </Link>
-      <Link
-        href='/notifications'
-        className={clsx({ 'dock-active text-primary': pathname.startsWith('/notifications') })}
-      >
-        <Bell />
-      </Link>
-      <Link
-        href={session?.user ? `/profile/${session.user.userId}` : '/login'}
-        className={clsx({
-          'dock-active text-primary': pathname.startsWith('/profile'),
-        })}
-      >
-        {session?.user ? <UserRound /> : <KeyRound />}
-      </Link>
-    </nav>
+    <>
+      <div className={clsx('pt-16 md:hidden', isKeyboardVisible && 'hidden')} />
+      <nav className={clsx('dock z-50 md:hidden', isKeyboardVisible && 'hidden')}>
+        <Link href='/' className={clsx({ 'dock-active text-primary': pathname === '/' })}>
+          <Home />
+        </Link>
+        <Link
+          href='/search'
+          className={clsx({ 'dock-active text-primary': pathname.startsWith('/search') })}
+        >
+          <Search />
+        </Link>
+        <Link
+          href='/board'
+          className={clsx({ 'dock-active text-primary': pathname.startsWith('/board') })}
+        >
+          <NotebookPen />
+        </Link>
+        <Link
+          href='/notifications'
+          className={clsx({ 'dock-active text-primary': pathname.startsWith('/notifications') })}
+        >
+          <Bell />
+        </Link>
+        <Link
+          href={session?.user ? `/profile/${session.user.userId}` : '/login'}
+          className={clsx({
+            'dock-active text-primary': pathname.startsWith('/profile'),
+          })}
+        >
+          {session?.user ? <UserRound /> : <KeyRound />}
+        </Link>
+      </nav>
+    </>
   )
 }

--- a/src/components/layout/MobileHeader/SearchHeader.tsx
+++ b/src/components/layout/MobileHeader/SearchHeader.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import SearchForm from '@/components/form/SearchForm'
+
+export default function SearchHeader() {
+  return (
+    <>
+      <div className='container-wrapper bg-base-100 fixed right-0 left-0 z-50 flex h-16 items-center justify-center border-b-1 border-b-gray-700 md:hidden'>
+        <SearchForm />
+      </div>
+      <div className='pb-16 md:hidden' />
+    </>
+  )
+}

--- a/src/components/layout/TopNav.tsx
+++ b/src/components/layout/TopNav.tsx
@@ -28,8 +28,8 @@ export default function TopNav() {
     <>
       <nav
         className={clsx(
-          'container-wrapper fixed right-0 left-0 z-50 hidden h-16 items-center border-b-1 transition-colors duration-300 md:flex',
-          scrolled ? 'bg-base-100 border-b-gray-700' : 'border-b-transparent'
+          'container-wrapper fixed right-0 left-0 z-50 hidden h-16 items-center border-b-1 transition-colors duration-200 md:flex',
+          !isOverlaid || scrolled ? 'bg-base-100 border-b-gray-700' : 'border-b-transparent'
         )}
       >
         <div className='flex-1'>


### PR DESCRIPTION
## 💡 Description
- 검색 페이지 UI 구현
- 레이아웃 여백 구조 개선


## ✨ Changes
- `SearchMovieItem` 추가: 검색 결과 항목을 보여주는 컴포넌트
- `SearchForm` 수정: input 배경을 투명하게 변경하고, 다른 페이지로 이동 시 입력값 초기화
- `SearchHeader` 추가: 모바일 전용 검색 헤더
- 페이지네이션 UI 추가: DaisyUI 기반으로 구현
- 검색 결과 없음 처리 수정: 기존 404 응답 대신 200 응답 반환, `movies.length === 0`일 때 메시지 표시
- `BottomNav` 동작 개선: 모바일 환경에서 키보드 등장 시 자동으로 숨겨지도록 처리
- 여백 구조 개선: 기존 `layout.tsx`에서 처리하던 상/하단 여백을 `TopNav`, `BottomNav`, `SearchHeader` 등에서 개별적으로 관리


## 📸 Screenshot
### 검색 결과 있을 때
![screencapture-localhost-3000-search-2025-05-13-15_01_16](https://github.com/user-attachments/assets/cb62d57b-73de-4e41-8630-da2593664a92)

### 검색 결과 없을 때
![screencapture-localhost-3000-search-2025-05-13-15_07_50](https://github.com/user-attachments/assets/0531a617-2fd9-4f7e-9e2a-da82d557fd37)

### 검색어 없을 때
![screencapture-localhost-3000-search-2025-05-13-15_02_00](https://github.com/user-attachments/assets/b75899f7-ef8b-45bf-834b-e796c9ac3872)

### 페이지네이션
<img width="372" alt="스크린샷 2025-05-13 13 06 49" src="https://github.com/user-attachments/assets/9f61aad2-a29d-4ca1-a63c-d0e5796dd029" />

### 모바일 키보드 등장 시 BottomNav 사라짐
[Galaxy-S21-Ultra-localhost--1ub5qv5vbi_hg.webm](https://github.com/user-attachments/assets/c800b4fc-c43a-4223-9143-86026a25a861)