### PR TITLE
[Feature] 영화 상세정보 페이지 UI, 홈 페이지 여백 구조 개선

### DIFF
--- a/src/app/movies/[id]/MyReviewSection.tsx
+++ b/src/app/movies/[id]/MyReviewSection.tsx
@@ -1,0 +1,110 @@
+import ReviewItem from '@/components/ui/ReviewItem'
+import { Review } from '@/types/api/common'
+import { Session } from 'next-auth'
+import Link from 'next/link'
+
+export default function MyReviewSection({
+  session,
+  myReview,
+  isThisWeekMovie,
+  isSunday,
+  certificationStatus,
+  movieId,
+}: {
+  session: Session | null
+  myReview: Review | null
+  isThisWeekMovie: boolean
+  isSunday: boolean
+  certificationStatus: string | null
+  movieId: string
+}) {
+  return (
+    <section className='container-wrapper'>
+      <h3 className='mb-3 text-xl font-semibold'>내가 쓴 리뷰</h3>
+      {session ? (
+        // 로그인 한 경우
+        <>
+          {myReview ? (
+            // 작성한 리뷰가 있는 경우
+            // ReviewItem으로 작성한 리뷰 출력
+            <ReviewItem review={myReview} withMovie={false} />
+          ) : (
+            // 작성한 리뷰가 없는 경우
+            // MyReviewBox으로 안내
+            <div className='bg-base-300 flex flex-col items-center gap-4 rounded-2xl p-4 md:flex-row md:justify-between md:gap-0'>
+              {isThisWeekMovie && !isSunday ? (
+                // 인증된 리뷰가 작성 가능한 경우 (이주의 영화이면서 일요일이 아닌 경우)
+                <>
+                  {certificationStatus === 'APPROVED' ? (
+                    // 인증된 경우
+                    // 리뷰 작성 안내
+                    <>
+                      <p>
+                        이 영화에 대한 <span className='font-bold'>{session.user?.nickname}</span>{' '}
+                        님의 생각이 궁금해요!
+                      </p>
+                      <Link className='btn btn-primary' href={`/board/create`}>
+                        인증된 리뷰 작성하기
+                      </Link>
+                    </>
+                  ) : (
+                    // 인증 안 된 경우
+                    // 인증 안내 및 일반 리뷰 작성 안내
+                    <>
+                      <p className='text-center break-keep'>
+                        이주의 영화에 대한{' '}
+                        <span className='font-bold'>{session.user?.nickname}</span> 님의 생각이
+                        궁금해요!
+                      </p>
+                      <div className='space-x-2 md:space-x-4'>
+                        <Link
+                          className='btn btn-primary btn-sm md:btn-md'
+                          href={`/profile/watch-verification`}
+                        >
+                          인증하고 리뷰 작성하기
+                        </Link>
+                        <Link
+                          className='btn btn-primary btn-sm md:btn-md'
+                          href={`/movies/${movieId}/reviews/create`}
+                        >
+                          일반 리뷰 작성하기
+                        </Link>
+                      </div>
+                    </>
+                  )}
+                </>
+              ) : (
+                // 인증된 리뷰가 작성 불가능한 경우 (이주의 영화가 아니거나 일요일인 경우)
+                // 일반 리뷰 작성 안내
+                <>
+                  <p>
+                    이 영화에 대한 <span className='font-bold'>{session.user?.nickname}</span> 님의
+                    생각이 궁금해요!
+                  </p>
+                  <Link
+                    className='btn btn-primary btn-sm md:btn-md'
+                    href={`/movies/${movieId}/reviews/create`}
+                  >
+                    리뷰 작성하기
+                  </Link>
+                </>
+              )}
+            </div>
+          )}
+        </>
+      ) : (
+        // 로그인 안한 경우
+        // 로그인 안내
+        <div className='bg-base-300 flex flex-col items-center gap-4 rounded-2xl p-4 md:flex-row md:justify-between md:gap-0'>
+          <p className='text-center break-keep'>
+            <span className='font-bold'>DeepDiview</span> 회원이 되셔서 이 영화에 대한 생각을
+            공유해주세요!
+          </p>
+          <Link className='btn btn-primary' href='/login'>
+            로그인하고 리뷰 작성하기
+          </Link>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,12 @@
 export const dynamic = 'force-dynamic'
 
 import BaseHeader from '@/components/layout/MobileHeader/BaseHeader'
+import LatestReviewSection from '@/components/ui/LatestReviewSection'
 import MovieCarousel from '@/components/ui/MovieCarousel'
 import OverlaidMovieHero from '@/components/ui/OverlaidMovieHero'
-import ReviewCarousel from '@/components/ui/ReviewCarousel'
 import { getIsSunday, getThisWeekMovieId } from '@/lib/api/discussion'
 import { getMovie, getPopularMovies } from '@/lib/api/movie'
 import { getLatestReviews } from '@/lib/api/review'
-import { ChevronRight } from 'lucide-react'
-import Link from 'next/link'
 
 export default async function HomePage() {
   const [popularMovies, { isSunday }, latestReviews, { tmdbId }] = await Promise.all([
@@ -23,24 +21,15 @@ export default async function HomePage() {
   return (
     <>
       <BaseHeader />
-      <div className='space-y-8'>
-        <OverlaidMovieHero movie={thisWeekMovie} isSunday={isSunday} />
+      <OverlaidMovieHero movie={thisWeekMovie} isSunday={isSunday} />
 
+      <div className='space-y-8'>
         <section className='container-wrapper'>
           <h3 className='mb-3 text-xl font-semibold'>인기 영화</h3>
           <MovieCarousel movies={popularMovies} />
         </section>
 
-        <section className='container-wrapper'>
-          <div className='flex justify-between'>
-            <h3 className='mb-3 text-xl font-semibold'>최신 리뷰</h3>
-            <Link className='flex' href={'/reviews'}>
-              더보기
-              <ChevronRight />
-            </Link>
-          </div>
-          <ReviewCarousel reviews={latestReviews.content} />
-        </section>
+        <LatestReviewSection latestReviews={latestReviews.content} href='/reviews' />
       </div>
     </>
   )

--- a/src/components/layout/MobileHeader/GoBackHeader.tsx
+++ b/src/components/layout/MobileHeader/GoBackHeader.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import clsx from 'clsx'
+import { usePathname, useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { ChevronLeft } from 'lucide-react'
+
+export default function GoBackHeader() {
+  const [scrolled, setScrolled] = useState(false)
+  const pathname = usePathname()
+  const router = useRouter()
+
+  const overlaidPaths = ['/', '/board']
+  const overlaidDynamicPaths = /^\/(movies)\/[^/]+$/.test(pathname)
+  const isOverlaid = overlaidPaths.includes(pathname) || overlaidDynamicPaths
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setScrolled(window.scrollY > 0)
+    }
+    window.addEventListener('scroll', handleScroll)
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  return (
+    <>
+      <div
+        className={clsx(
+          'container-wrapper fixed right-0 left-0 z-50 flex items-center overflow-hidden transition-all duration-100 md:hidden',
+          scrolled ? 'h-0' : 'h-16'
+        )}
+      >
+        <div className='flex flex-1 gap-2'>
+          <button onClick={() => router.back()} type='button'>
+            <ChevronLeft strokeWidth={3} />
+          </button>
+          <Link href='/'>
+            <h1 className='text-2xl font-bold'>Deepdiview</h1>
+          </Link>
+        </div>
+      </div>
+      {!isOverlaid && <div className='hidden pb-16 md:block' />}
+    </>
+  )
+}

--- a/src/components/ui/CertifiedBadge.tsx
+++ b/src/components/ui/CertifiedBadge.tsx
@@ -1,0 +1,9 @@
+import { BadgeCheck } from 'lucide-react'
+
+export default function CertifiedBadge() {
+  return (
+    <div className='badge badge-primary h-5 w-5 rounded-full border-2 p-0'>
+      <BadgeCheck />
+    </div>
+  )
+}

--- a/src/components/ui/LatestReviewSection.tsx
+++ b/src/components/ui/LatestReviewSection.tsx
@@ -1,0 +1,27 @@
+import { ChevronRight } from 'lucide-react'
+import Link from 'next/link'
+import ReviewCarousel from './ReviewCarousel'
+import { Review } from '@/types/api/common'
+
+export default function LatestReviewSection({
+  latestReviews,
+  href,
+  withMovie = true,
+}: {
+  latestReviews: Review[]
+  href: string
+  withMovie?: boolean
+}) {
+  return (
+    <section className='container-wrapper'>
+      <div className='flex justify-between'>
+        <h3 className='mb-3 text-xl font-semibold'>최신 리뷰</h3>
+        <Link className='flex' href={href}>
+          더보기
+          <ChevronRight />
+        </Link>
+      </div>
+      <ReviewCarousel reviews={latestReviews} withMovie={withMovie} />
+    </section>
+  )
+}

--- a/src/components/ui/ReviewCarousel.tsx
+++ b/src/components/ui/ReviewCarousel.tsx
@@ -1,14 +1,17 @@
 'use client'
 
 import { Review } from '@/types/api/common'
-import { ChevronLeft, ChevronRight, MessageCircle, Heart } from 'lucide-react'
-import Image from 'next/image'
-import Link from 'next/link'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useRef, useState, useEffect } from 'react'
-import Rating from './Rating'
-import { getRelativeTime } from '@/lib/utils/date'
+import ReviewItem from './ReviewItem'
 
-export default function ReviewCarousel({ reviews }: { reviews: Review[] }) {
+export default function ReviewCarousel({
+  reviews,
+  withMovie = true,
+}: {
+  reviews: Review[]
+  withMovie?: boolean
+}) {
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const [isAtStart, setIsAtStart] = useState(true)
   const [isAtEnd, setIsAtEnd] = useState(false)
@@ -59,53 +62,7 @@ export default function ReviewCarousel({ reviews }: { reviews: Review[] }) {
             className='w-full flex-shrink-0 snap-start md:w-[calc((100%-8px)/2)] lg:w-[calc((100%-24px)/3)]'
             key={review.reviewId}
           >
-            <Link href={`/reviews/${review.reviewId}`}>
-              <div className='bg-base-300 space-y-2 rounded-xl p-4'>
-                <div className='flex items-center justify-between'>
-                  <div className='flex items-center gap-2'>
-                    <div>
-                      <Image
-                        src={`${review.profileImageUrl}`}
-                        alt='프로필 사진'
-                        width={33}
-                        height={33}
-                        className='aspect-square rounded-full'
-                      />
-                    </div>
-                    <div>
-                      <p className='text-sm'>{review.nickname}</p>
-                      <p className='text-xs text-gray-500'>{getRelativeTime(review.createdAt)}</p>
-                    </div>
-                  </div>
-                  <Rating rating={review.rating} readOnly={true} />
-                </div>
-                <div className='flex gap-3'>
-                  <div className='relative aspect-[2/3] flex-1 shrink-0'>
-                    <Image
-                      src={`https://image.tmdb.org/t/p/w500${review.posterPath}`}
-                      alt='영화 포스터'
-                      fill
-                      className='rounded-lg object-cover'
-                    />
-                  </div>
-                  <div className='flex-2 space-y-1 overflow-hidden'>
-                    <p className='truncate overflow-hidden text-lg font-bold whitespace-nowrap'>
-                      {review.reviewTitle}
-                    </p>
-                    <p className='line-clamp-3'>{review.reviewContent}</p>
-                  </div>
-                </div>
-                <div className='flex justify-between gap-3'>
-                  <p className='truncate overflow-hidden whitespace-nowrap'>{review.movieTitle}</p>
-                  <div className='flex'>
-                    <Heart />
-                    <p className='mr-3'>{review.likeCount}</p>
-                    <MessageCircle />
-                    <p>{review.commentCount}</p>
-                  </div>
-                </div>
-              </div>
-            </Link>
+            <ReviewItem review={review} withMovie={withMovie} />
           </div>
         ))}
       </div>

--- a/src/components/ui/ReviewItem.tsx
+++ b/src/components/ui/ReviewItem.tsx
@@ -1,0 +1,77 @@
+import { getRelativeTime } from '@/lib/utils/date'
+import { Review } from '@/types/api/common'
+import Image from 'next/image'
+import Link from 'next/link'
+import Rating from './Rating'
+import { Heart, MessageCircle } from 'lucide-react'
+import clsx from 'clsx'
+import CertifiedBadge from './CertifiedBadge'
+
+export default function ReviewItem({
+  review,
+  withMovie = true,
+}: {
+  review: Review
+  withMovie?: boolean
+}) {
+  return (
+    <Link href={`/reviews/${review.reviewId}`}>
+      <div
+        className={clsx(
+          'bg-base-300 rounded-xl p-4',
+          withMovie ? 'space-y-2' : 'flex h-56 flex-col gap-3'
+        )}
+      >
+        {/* 상단 유저 정보 */}
+        <div className='flex items-center justify-between'>
+          <div className='flex items-center gap-2'>
+            <Image
+              src={`${review.profileImageUrl}`}
+              alt='프로필 사진'
+              width={33}
+              height={33}
+              className='aspect-square rounded-full'
+            />
+            <div>
+              <div className='flex items-center gap-1'>
+                <p className='text-sm'>{review.nickname}</p>
+                {review.certified && <CertifiedBadge />}
+              </div>
+              <p className='text-xs text-gray-500'>{getRelativeTime(review.createdAt)}</p>
+            </div>
+          </div>
+          <Rating rating={review.rating} readOnly={true} />
+        </div>
+        {/* 중간 영화 포스터 & 리뷰 */}
+        <div className={clsx(withMovie ? 'flex gap-3' : 'flex-1 space-y-1 overflow-hidden')}>
+          {withMovie && (
+            <div className='relative aspect-[2/3] flex-1 shrink-0'>
+              <Image
+                src={`https://image.tmdb.org/t/p/w500${review.posterPath}`}
+                alt={`${review.movieTitle} 포스터`}
+                fill
+                className='rounded-lg object-cover'
+              />
+            </div>
+          )}
+          <div className={clsx(withMovie ? 'flex-2 space-y-1 overflow-hidden' : 'space-y-1')}>
+            <p className='line-clamp-1 text-lg font-bold'>{review.reviewTitle}</p>
+            <p className='line-clamp-3 break-words'>{review.reviewContent}</p>
+          </div>
+        </div>
+        {/* 하단 영화 제목 & 좋아요, 댓글 */}
+        <div className='flex justify-between gap-3'>
+          {withMovie && (
+            <p className='truncate overflow-hidden whitespace-nowrap'>{review.movieTitle}</p>
+          )}
+          <div className='flex'>
+            <Heart />
+            <p className='mr-3'>{review.likeCount}</p>
+            <MessageCircle />
+            <p>{review.commentCount}</p>
+          </div>
+        </div>
+      </div>
+    </Link>
+  )
+}


### PR DESCRIPTION
## 💡 Description
- 영화 상세정보 페이지 UI 구현
- 홈 페이지에서 컴포넌트 추출하고, 여백 구조 개선

## ✨ Changes
### 공통 컴포넌트 추출 및 레이아웃 정리
- `OverlaidMovieHero`의 하단 여백 제거: 상세 페이지와 구조 통일
- `LatestReviewSection` 컴포넌트 추가: 홈에서 추출하여 공통화, `withMovie` prop으로 영화 정보 유무에 따라 동작 분기

### 리뷰 관련 컴포넌트 구성
- `ReviewCarousel` 수정: 상세 페이지에서 영화 정보 없이 사용할 수 있도록 `withMovie` prop 추가
  - `ReviewItem` 컴포넌트 추가: `ReviewCarousel`에서 분리, `withMovie` prop으로 영화 정보 표시 여부 제어
    - `CertifiedBadge` 추가: 인증된 사용자의 리뷰에 표시되는 뱃지 컴포넌트

### 유저 리뷰 섹션 구성
- `MyReviewSection` 추가: 해당 영화에 대해 내가 작성한 리뷰를 조건에 따라 보여주거나, 로그인 / 시청 인증 / 일반 리뷰 작성 / 인증된 리뷰 작성 안내

### 모바일 레이아웃
- `GoBackHeader` 추가: 모바일 전용 뒤로가기 헤더 컴포넌트


## 📸 Screenshot
### 홈 페이지 OverlaidMovieHero 하단 여백 제거
<img width="1041" alt="스크린샷 2025-05-14 18 04 48" src="https://github.com/user-attachments/assets/d027ceb8-4c14-49ea-9bb8-670fb3bbb9dc" />

### 영화 상세 정보 페이지 PC
![screencapture-localhost-3000-movies-297762-2025-05-14-18_07_37](https://github.com/user-attachments/assets/dd34740e-2be1-43f7-bd03-9df73eac652d)

### 영화 상세 정보 페이지 모바일
[Galaxy-S21-Ultra-localhost-yakxi1hf_8jqtz.webm](https://github.com/user-attachments/assets/1af249fe-4738-4952-9d65-d214ef14bced)

### MyReviewSection
#### 로그인 안내
<img width="944" alt="스크린샷 2025-05-14 18 13 45" src="https://github.com/user-attachments/assets/093a47d6-e41e-4ae7-9d85-82a165ea32cb" />

#### 인증, 일반 리뷰 작성 안내
<img width="947" alt="스크린샷 2025-05-14 18 14 12" src="https://github.com/user-attachments/assets/f20df58d-d983-47c1-b4fe-4341932d49e4" />

### 일반 리뷰 작성 안내
<img width="940" alt="스크린샷 2025-05-14 18 13 12" src="https://github.com/user-attachments/assets/7b50e1b4-7a54-4eea-9256-a1a7bf8bffc9" />

### 인증된 리뷰 작성 안내
<img width="939" alt="스크린샷 2025-05-14 18 13 32" src="https://github.com/user-attachments/assets/cd263e34-309e-4300-996c-1889debeb3d7" />
