### PR TITLE
[Fix] 검색 페이지에서 빈 검색어일 때 API 호출 방지

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -13,6 +13,17 @@ export default async function SearchPage({
   const trimmedTitle = title.trim()
   const pageNumber = Number(page)
 
+  if (!trimmedTitle) {
+    return (
+      <>
+        <SearchHeader />
+        <div className='container-wrapper'>
+          <p className='py-4'>검색어를 입력해 주세요.</p>
+        </div>
+      </>
+    )
+  }
+
   const {
     content: movies,
     totalElements,
@@ -23,9 +34,7 @@ export default async function SearchPage({
     <>
       <SearchHeader />
       <div className='container-wrapper'>
-        {!trimmedTitle ? (
-          <p className='py-4'>검색어를 입력해 주세요.</p>
-        ) : movies.length === 0 ? (
+        {movies.length === 0 ? (
           <p className='py-4'>
             &quot;<span className='font-bold'>{trimmedTitle}</span>&quot;에 대한 검색 결과가
             없습니다.
@@ -46,7 +55,6 @@ export default async function SearchPage({
             </ul>
           </>
         )}
-        {/* 페이지네이션 */}
         {totalPages > 1 && (
           <div className='join mt-2 w-full justify-center md:mt-4'>
             {pageNumber > 3 && (
@@ -63,38 +71,36 @@ export default async function SearchPage({
                 )}
               </>
             )}
-            <>
-              {Array.from({ length: 5 }).map((_, i) => {
-                const targetPage = pageNumber - 2 + i
-                if (targetPage < 1 || targetPage > totalPages) return null
-                return (
-                  <Link
-                    className={clsx(
-                      'join-item btn btn-sm md:btn-md',
-                      targetPage === pageNumber && 'bg-primary pointer-events-none'
-                    )}
-                    key={targetPage}
-                    href={`/search?title=${encodeURIComponent(trimmedTitle)}&page=${targetPage}`}
-                  >
-                    {targetPage}
-                  </Link>
-                )
-              })}
-              {pageNumber + 2 < totalPages && (
-                <>
-                  {pageNumber + 3 < totalPages && (
-                    <button className='join-item btn btn-sm btn-disabled md:btn-md'>···</button>
+            {Array.from({ length: 5 }).map((_, i) => {
+              const targetPage = pageNumber - 2 + i
+              if (targetPage < 1 || targetPage > totalPages) return null
+              return (
+                <Link
+                  className={clsx(
+                    'join-item btn btn-sm md:btn-md',
+                    targetPage === pageNumber && 'bg-primary pointer-events-none'
                   )}
-                  <Link
-                    className='join-item btn btn-sm md:btn-md'
-                    key={totalPages}
-                    href={`/search?title=${encodeURIComponent(trimmedTitle)}&page=${totalPages}`}
-                  >
-                    {totalPages}
-                  </Link>
-                </>
-              )}
-            </>
+                  key={targetPage}
+                  href={`/search?title=${encodeURIComponent(trimmedTitle)}&page=${targetPage}`}
+                >
+                  {targetPage}
+                </Link>
+              )
+            })}
+            {pageNumber + 2 < totalPages && (
+              <>
+                {pageNumber + 3 < totalPages && (
+                  <button className='join-item btn btn-sm btn-disabled md:btn-md'>···</button>
+                )}
+                <Link
+                  className='join-item btn btn-sm md:btn-md'
+                  key={totalPages}
+                  href={`/search?title=${encodeURIComponent(trimmedTitle)}&page=${totalPages}`}
+                >
+                  {totalPages}
+                </Link>
+              </>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## 💡 Description
- 검색어 없이 `/search` 페이지에 접근할 경우, 불필요한 API 호출이 발생하던 문제를 수정
- 특히 모바일에서 직접 URL 접근 시 빈 검색어 상태로 API 호출이 이뤄지며 에러가 발생하던 이슈 해결


## ✨ Changes
- 검색어가 없을 경우 (`title`이 빈 문자열일 경우) 얼리 리턴하도록 처리
- `getSearchedMovies` 함수 호출을 조건부로 실행하여 서버 요청 차단


## 📸 Screenshot
### 검색어 없이 모바일에서 검색 페이지 접근 시
![Galaxy-S21-Ultra-localhost](https://github.com/user-attachments/assets/ea54cf1d-94e3-4aab-9510-462822a5997e)