### PR TITLE
[Refactor] 영화 응답 구조 변경에 따른 리뷰 분리 처리

### DIFF
--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -10,6 +10,7 @@ import { getMovie } from '@/lib/api/movie'
 
 import { notFound } from 'next/navigation'
 import MyReviewSection from './MyReviewSection'
+import { getReviews } from '@/lib/api/review'
 
 export default async function MoviesPage({ params }: { params: Promise<{ id: string }> }) {
   const [{ id }, session, { tmdbId }, { isSunday }] = await Promise.all([
@@ -35,6 +36,8 @@ export default async function MoviesPage({ params }: { params: Promise<{ id: str
     throw error
   }
 
+  const { content: reviews } = await getReviews(id, !!session, session?.accessToken, { size: 9 })
+
   return (
     <>
       <GoBackHeader />
@@ -49,7 +52,7 @@ export default async function MoviesPage({ params }: { params: Promise<{ id: str
           movieId={id}
         />
         <LatestReviewSection
-          latestReviews={movie.reviews}
+          latestReviews={reviews}
           href={`/movies/${id}/reviews`}
           withMovie={false}
         />

--- a/src/types/api/movie.ts
+++ b/src/types/api/movie.ts
@@ -26,7 +26,6 @@ export interface Movie {
   backdrop_path: string
   genre_ids: number[]
   genre_names: string[]
-  reviews: Review[]
   myReview: Review | null
   ratingStats: {
     ratingAverage: number


### PR DESCRIPTION
## 💡 Description
- 기존 영화 API 응답에서 함께 내려오던 `reviews` 필드가 제거됨에 따라 구조를 변경


## ✨ Changes
- `Movie` 타입에서 `reviews` 필드 제거
- 영화 상세 페이지에서 `getReviews()`를 호출하여 리뷰 데이터 별도 요청
- `LatestReviewSection` 컴포넌트에 props 형태로 리뷰 데이터 전달