### PR TITLE
[Feature] 최신 리뷰 페이지 구현, GoBackHeader UX 개선

### DIFF
--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from '@/auth'
 import GoBackHeader from '@/components/layout/MobileHeader/GoBackHeader'
-import ReviewItem from '@/components/ui/ReviewItem'
 import { getLatestReviews } from '@/lib/api/review'
+import ReviewList from '../../components/ui/ReviewList'
 
 export default async function ReviewsPage() {
   const session = await auth()
@@ -10,6 +10,8 @@ export default async function ReviewsPage() {
     size: 12,
   })
 
+  console.log(reviews)
+
   return (
     <>
       <GoBackHeader>
@@ -17,11 +19,7 @@ export default async function ReviewsPage() {
       </GoBackHeader>
       <div className='container-wrapper'>
         <h2 className='mt-4 mb-3 hidden text-xl font-semibold md:block'>최신 리뷰</h2>
-        <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'>
-          {reviews.content.map((review) => (
-            <ReviewItem key={review.reviewId} review={review} />
-          ))}
-        </div>
+        <ReviewList initialReviews={reviews.content} initialLast={reviews.last} />
       </div>
     </>
   )

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -1,0 +1,28 @@
+import { auth } from '@/auth'
+import GoBackHeader from '@/components/layout/MobileHeader/GoBackHeader'
+import ReviewItem from '@/components/ui/ReviewItem'
+import { getLatestReviews } from '@/lib/api/review'
+
+export default async function ReviewsPage() {
+  const session = await auth()
+  const reviews = await getLatestReviews(!!session, session?.accessToken, {
+    page: 0,
+    size: 12,
+  })
+
+  return (
+    <>
+      <GoBackHeader>
+        <h2 className='text-xl font-semibold'>최신 리뷰</h2>
+      </GoBackHeader>
+      <div className='container-wrapper'>
+        <h2 className='mt-4 mb-3 hidden text-xl font-semibold md:block'>최신 리뷰</h2>
+        <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'>
+          {reviews.content.map((review) => (
+            <ReviewItem key={review.reviewId} review={review} />
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/layout/MobileHeader/GoBackHeader.tsx
+++ b/src/components/layout/MobileHeader/GoBackHeader.tsx
@@ -1,13 +1,16 @@
 'use client'
 
-import { ReactNode, useEffect, useState } from 'react'
+import { ReactNode, useEffect, useRef, useState } from 'react'
 import clsx from 'clsx'
 import { usePathname, useRouter } from 'next/navigation'
 import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
 
 export default function GoBackHeader({ children }: { children?: ReactNode }) {
+  const [hideHeader, setHideHeader] = useState(false)
   const [scrolled, setScrolled] = useState(false)
+  const lastScrollY = useRef(0)
+
   const pathname = usePathname()
   const router = useRouter()
 
@@ -17,8 +20,21 @@ export default function GoBackHeader({ children }: { children?: ReactNode }) {
 
   useEffect(() => {
     const handleScroll = () => {
-      setScrolled(window.scrollY > 0)
+      const currentY = window.scrollY
+
+      // 헤더 배경, 하단 보더 처리 (스크롤이 10px 이상 내려간 후에만 불투명 적용)
+      setScrolled(currentY > 10)
+
+      // 헤더 숨김 처리 (스크롤을 아래로 내릴 경우 숨기기, 위로 올리면 다시 보이기)
+      if (currentY > lastScrollY.current && currentY > 5) {
+        setHideHeader(true)
+      } else if (currentY < lastScrollY.current) {
+        setHideHeader(false)
+      }
+
+      lastScrollY.current = currentY
     }
+
     window.addEventListener('scroll', handleScroll)
     return () => window.removeEventListener('scroll', handleScroll)
   }, [])
@@ -27,8 +43,9 @@ export default function GoBackHeader({ children }: { children?: ReactNode }) {
     <>
       <div
         className={clsx(
-          'container-wrapper fixed right-0 left-0 z-50 flex items-center overflow-hidden transition-all duration-100 md:hidden',
-          scrolled ? 'h-0' : 'h-16'
+          'container-wrapper fixed right-0 left-0 z-50 flex items-center border-b-1 transition-all duration-200 md:hidden',
+          hideHeader ? 'h-0 overflow-hidden' : 'h-16',
+          scrolled ? 'bg-base-100 border-b-gray-700' : 'border-b-transparent bg-transparent'
         )}
       >
         <div className='flex flex-1 gap-2'>

--- a/src/components/layout/MobileHeader/GoBackHeader.tsx
+++ b/src/components/layout/MobileHeader/GoBackHeader.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 import clsx from 'clsx'
 import { usePathname, useRouter } from 'next/navigation'
-import Link from 'next/link'
 import { ChevronLeft } from 'lucide-react'
+import Link from 'next/link'
 
-export default function GoBackHeader() {
+export default function GoBackHeader({ children }: { children?: ReactNode }) {
   const [scrolled, setScrolled] = useState(false)
   const pathname = usePathname()
   const router = useRouter()
@@ -35,12 +35,14 @@ export default function GoBackHeader() {
           <button onClick={() => router.back()} type='button'>
             <ChevronLeft strokeWidth={3} />
           </button>
-          <Link href='/'>
-            <h1 className='text-2xl font-bold'>Deepdiview</h1>
-          </Link>
+          {children ?? (
+            <Link href='/'>
+              <h1 className='text-2xl font-bold'>Deepdiview</h1>
+            </Link>
+          )}
         </div>
       </div>
-      {!isOverlaid && <div className='hidden pb-16 md:block' />}
+      {!isOverlaid && <div className='pb-16 md:hidden' />}
     </>
   )
 }

--- a/src/components/ui/ReviewList.tsx
+++ b/src/components/ui/ReviewList.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import ReviewItem from '@/components/ui/ReviewItem'
+import { getLatestReviews } from '@/lib/api/review'
+import type { Review } from '@/types/api/common'
+
+export default function ReviewList({
+  initialReviews,
+  initialLast,
+}: {
+  initialReviews: Review[]
+  initialLast: boolean
+}) {
+  const [reviews, setReviews] = useState(initialReviews)
+  const [page, setPage] = useState(1)
+  const [hasMore, setHasMore] = useState(!initialLast)
+  const [isFetching, setIsFetching] = useState(false)
+
+  const loaderRef = useRef<HTMLDivElement | null>(null)
+  const isFetchingRef = useRef(false)
+
+  useEffect(() => {
+    const target = loaderRef.current
+    if (!target || !hasMore) return
+
+    const observer = new IntersectionObserver(
+      async ([entry]) => {
+        if (entry.isIntersecting && !isFetchingRef.current) {
+          isFetchingRef.current = true
+          setIsFetching(true)
+
+          const res = await getLatestReviews(false, undefined, { page, size: 12 })
+          setReviews((prev) => [...prev, ...res.content])
+          setPage((prev) => prev + 1)
+          if (res.last) setHasMore(false)
+
+          setIsFetching(false)
+          isFetchingRef.current = false
+        }
+      },
+      {
+        threshold: 0.3,
+      }
+    )
+
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [page, hasMore])
+
+  return (
+    <>
+      <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'>
+        {reviews.map((review) => (
+          <ReviewItem key={review.reviewId} review={review} />
+        ))}
+      </div>
+      {isFetching && (
+        <div className='mt-2 w-full text-center md:mt-3'>
+          <span className='loading loading-ring loading-xl text-primary' />
+        </div>
+      )}
+      {hasMore && <div ref={loaderRef} className='h-1 w-full opacity-0' />}
+    </>
+  )
+}

--- a/src/lib/api/review.ts
+++ b/src/lib/api/review.ts
@@ -84,8 +84,13 @@ export async function getReviews(
 
 // 최신 리뷰 조회
 export async function getLatestReviews(
+  withAuth?: boolean,
+  token?: string,
   params?: GetReviewsParams
 ): Promise<GetLatestReviewsResponse> {
   const query = params ? `?${toQueryString(params)}` : ''
-  return apiClient<GetLatestReviewsResponse>(`/reviews/latest${query}`)
+  return apiClient<GetLatestReviewsResponse>(`/reviews/latest${query}`, {
+    withAuth,
+    token,
+  })
 }


### PR DESCRIPTION
## 💡 Description
- 최신 리뷰 페이지 추가 및 무한 스크롤 리스트를 구현
- `GoBackHeader` 스크롤 UX 개선


## ✨ Changes
- `ReviewsPage` 추가: 최신 리뷰를 보여주는 별도 페이지 구현
- `ReviewList` 컴포넌트 추가
  - 12개 단위로 무한 스크롤 로딩
  - 반응형 그리드 레이아웃 (모바일 1열 / md 2열 / lg 3열)
  - `isFetchingRef`를 활용해 중복 fetch 방지 (IntersectionObserver 중복 감지 문제 해결)
  
- `GoBackHeader` 개선
  - `children`을 받아 페이지 제목 삽입 가능 (기본값은 로고)
  - 스크롤 UX 개선
    - 기존: 스크롤을 조금만 내려도 바로 헤더가 숨겨지고, 최상단으로 올라가야 다시 나타났음
    - 변경: 스크롤 방향을 기준으로 show/hide 처리로 위로 스크롤할 때 다시 나타남
      → 무한 스크롤 환경에서의 불편함을 해소하고, 더 자연스러운 UX 제공
    - 배경색은 `scrollY > 10`부터 적용: 헤더가 사라지기 전에 배경이 먼저 바뀌는 이질감 해소


## 📸 Screenshot
### lg 3열
<img width="1423" alt="스크린샷 2025-05-15 16 59 22" src="https://github.com/user-attachments/assets/bb6d8d18-827f-461d-8b0b-d6dbf89f0345" />

### md 2열
<img width="933" alt="스크린샷 2025-05-15 16 59 30" src="https://github.com/user-attachments/assets/37b6eae6-2ea3-4a98-8635-1bb79c67cef4" />

### 모바일 + 로딩
[모바일 화면, 로딩.webm](https://github.com/user-attachments/assets/e580ee0a-461f-45d0-beca-af42279c5b0d)

### GoBackHeader
[GoBackHeader 수정.webm](https://github.com/user-attachments/assets/e76b24f4-7dc2-42d1-84f1-4612340a78dc)
