### PR TITLE
[Feature] 영화 리뷰 페이지 UI, likedByUser 표시

### DIFF
--- a/src/app/movies/[id]/reviews/page.tsx
+++ b/src/app/movies/[id]/reviews/page.tsx
@@ -1,20 +1,17 @@
 export const dynamic = 'force-dynamic'
 
 import { auth } from '@/auth'
+import GoBackHeader from '@/components/layout/MobileHeader/GoBackHeader'
+import ReviewList from '@/components/ui/ReviewList'
 import { getReviews } from '@/lib/api/review'
-import { CircleCheck, CircleUserRound, MessageCircle, ThumbsUp } from 'lucide-react'
-import Image from 'next/image'
-import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
 export default async function MoviesReviewsPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params
-  const session = await auth()
+  const [{ id }, session] = await Promise.all([params, auth()])
 
-  // TODO: 페이지네이션, 무한 스크롤, 정렬
   let reviews
   try {
-    reviews = await getReviews(id, !!session, session?.accessToken, { page: 0 })
+    reviews = await getReviews(id, !!session, session?.accessToken, { page: 0, size: 12 })
   } catch (error) {
     if (error instanceof Error && error.message === 'MOVIE_NOT_FOUND') {
       return notFound()
@@ -25,44 +22,15 @@ export default async function MoviesReviewsPage({ params }: { params: Promise<{ 
 
   return (
     <>
-      <h2>리뷰</h2>
-      <hr />
-      <ul>
-        {reviews.content.map((review) => (
-          <li key={review.reviewId}>
-            <div className='flex justify-between'>
-              <Link className='flex' href={`/profile/${review.userId}`}>
-                {review.profileImageUrl ? (
-                  <Image
-                    src={`${review.profileImageUrl}`}
-                    alt='프로필 사진'
-                    width={20}
-                    height={20}
-                  />
-                ) : (
-                  <CircleUserRound />
-                )}
-                <p>{review.nickname}</p>
-                {review.certified && <CircleCheck />}
-              </Link>
-              <p>{review.rating}</p>
-            </div>
-            <Link href={`/reviews/${review.reviewId}`}>
-              <div>
-                <p>{review.reviewTitle}</p>
-                <p>{review.reviewContent}</p>
-              </div>
-              <div className='flex'>
-                <ThumbsUp />
-                {review.likeCount}
-                <MessageCircle />
-                {review.commentCount}
-              </div>
-            </Link>
-            <hr />
-          </li>
-        ))}
-      </ul>
+      <GoBackHeader>
+        <h2 className='text-xl font-semibold'>{reviews.content[0]?.movieTitle} 리뷰</h2>
+      </GoBackHeader>
+      <div className='container-wrapper'>
+        <h2 className='mt-4 mb-3 hidden text-xl font-semibold md:block'>
+          {reviews.content[0]?.movieTitle} 리뷰
+        </h2>
+        <ReviewList initialReviews={reviews.content} initialLast={reviews.last} withMovie={false} />
+      </div>
     </>
   )
 }

--- a/src/app/movies/[id]/reviews/page.tsx
+++ b/src/app/movies/[id]/reviews/page.tsx
@@ -4,32 +4,104 @@ import { auth } from '@/auth'
 import GoBackHeader from '@/components/layout/MobileHeader/GoBackHeader'
 import ReviewList from '@/components/ui/ReviewList'
 import { getReviews } from '@/lib/api/review'
+import { ReviewSortField } from '@/types/api/common'
+import clsx from 'clsx'
+import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
-export default async function MoviesReviewsPage({ params }: { params: Promise<{ id: string }> }) {
-  const [{ id }, session] = await Promise.all([params, auth()])
+export default async function MoviesReviewsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>
+  searchParams: Promise<{ sort?: ReviewSortField }>
+}) {
+  const [{ id }, { sort = 'createdAt' }, session] = await Promise.all([
+    params,
+    searchParams,
+    auth(),
+  ])
 
   let reviews
   try {
-    reviews = await getReviews(id, !!session, session?.accessToken, { page: 0, size: 12 })
+    reviews = await getReviews(id, !!session, session?.accessToken, {
+      page: 0,
+      size: 12,
+      sort: `${sort},desc`,
+    })
   } catch (error) {
     if (error instanceof Error && error.message === 'MOVIE_NOT_FOUND') {
       return notFound()
     }
     throw error
   }
-  console.log(reviews)
 
   return (
     <>
       <GoBackHeader>
-        <h2 className='text-xl font-semibold'>{reviews.content[0]?.movieTitle} 리뷰</h2>
+        <h2 className='line-clamp-1 flex-1 text-xl font-semibold'>
+          {reviews.content[0]?.movieTitle}
+        </h2>
+        <div className='flex space-x-3'>
+          <Link
+            className={clsx(
+              'btn btn-primary rounded-xl',
+              sort === 'createdAt' ? 'pointer-events-none' : 'btn-soft'
+            )}
+            prefetch={false}
+            href={`/movies/${id}/reviews?sort=createdAt`}
+          >
+            최신
+          </Link>
+          <Link
+            className={clsx(
+              'btn btn-primary rounded-xl',
+              sort === 'likeCount' ? 'pointer-events-none' : 'btn-soft'
+            )}
+            prefetch={false}
+            href={`/movies/${id}/reviews?sort=likeCount`}
+          >
+            인기
+          </Link>
+        </div>
       </GoBackHeader>
       <div className='container-wrapper'>
-        <h2 className='mt-4 mb-3 hidden text-xl font-semibold md:block'>
-          {reviews.content[0]?.movieTitle} 리뷰
-        </h2>
-        <ReviewList initialReviews={reviews.content} initialLast={reviews.last} withMovie={false} />
+        <div className='flex items-center justify-between py-1'>
+          <h2 className='mt-4 mb-3 line-clamp-1 hidden text-xl font-semibold md:block'>
+            {reviews.content[0]?.movieTitle}
+          </h2>
+          <div className='hidden space-x-3 md:block'>
+            <Link
+              className={clsx(
+                'btn btn-primary rounded-xl',
+                sort === 'createdAt' ? 'pointer-events-none' : 'btn-soft'
+              )}
+              prefetch={false}
+              href={`/movies/${id}/reviews?sort=createdAt`}
+            >
+              최신
+            </Link>
+            <Link
+              className={clsx(
+                'btn btn-primary rounded-xl',
+                sort === 'likeCount' ? 'pointer-events-none' : 'btn-soft'
+              )}
+              href={`/movies/${id}/reviews?sort=likeCount`}
+              prefetch={false}
+            >
+              인기
+            </Link>
+          </div>
+        </div>
+
+        <ReviewList
+          session={session}
+          initialReviews={reviews.content}
+          initialLast={reviews.last}
+          withMovie={false}
+          movieId={id}
+          sort={sort}
+        />
       </div>
     </>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 export const dynamic = 'force-dynamic'
 
+import { auth } from '@/auth'
 import BaseHeader from '@/components/layout/MobileHeader/BaseHeader'
 import LatestReviewSection from '@/components/ui/LatestReviewSection'
 import MovieCarousel from '@/components/ui/MovieCarousel'
@@ -9,14 +10,17 @@ import { getMovie, getPopularMovies } from '@/lib/api/movie'
 import { getLatestReviews } from '@/lib/api/review'
 
 export default async function HomePage() {
-  const [popularMovies, { isSunday }, latestReviews, { tmdbId }] = await Promise.all([
+  const [session, popularMovies, { isSunday }, { tmdbId }] = await Promise.all([
+    auth(),
     getPopularMovies(),
     getIsSunday(),
-    getLatestReviews(),
     getThisWeekMovieId(),
   ])
 
-  const thisWeekMovie = await getMovie(tmdbId.toString())
+  const [latestReviews, thisWeekMovie] = await Promise.all([
+    getLatestReviews(!!session, session?.accessToken),
+    getMovie(tmdbId.toString()),
+  ])
 
   return (
     <>

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -19,7 +19,7 @@ export default async function ReviewsPage() {
       </GoBackHeader>
       <div className='container-wrapper'>
         <h2 className='mt-4 mb-3 hidden text-xl font-semibold md:block'>최신 리뷰</h2>
-        <ReviewList initialReviews={reviews.content} initialLast={reviews.last} />
+        <ReviewList session={session} initialReviews={reviews.content} initialLast={reviews.last} />
       </div>
     </>
   )

--- a/src/components/layout/MobileHeader/GoBackHeader.tsx
+++ b/src/components/layout/MobileHeader/GoBackHeader.tsx
@@ -48,7 +48,7 @@ export default function GoBackHeader({ children }: { children?: ReactNode }) {
           scrolled ? 'bg-base-100 border-b-gray-700' : 'border-b-transparent bg-transparent'
         )}
       >
-        <div className='flex flex-1 gap-2'>
+        <div className='flex flex-1 items-center gap-2'>
           <button onClick={() => router.back()} type='button'>
             <ChevronLeft strokeWidth={3} />
           </button>

--- a/src/components/ui/ReviewItem.tsx
+++ b/src/components/ui/ReviewItem.tsx
@@ -60,15 +60,19 @@ export default function ReviewItem({
           </div>
         </div>
         {/* 하단 영화 제목 & 좋아요, 댓글 */}
-        <div className='flex justify-between gap-3'>
+        <div className={clsx('flex', withMovie && 'justify-between gap-3')}>
           {withMovie && (
             <p className='truncate overflow-hidden whitespace-nowrap'>{review.movieTitle}</p>
           )}
-          <div className='flex'>
-            <Heart />
-            <p className='mr-3'>{review.likeCount}</p>
-            <MessageCircle />
-            <p>{review.commentCount}</p>
+          <div className='flex gap-3'>
+            <div className='flex gap-1'>
+              <Heart className={clsx(review.likedByUser && 'fill-primary stroke-primary')} />
+              <p>{review.likeCount}</p>
+            </div>
+            <div className='flex gap-1'>
+              <MessageCircle />
+              <p>{review.commentCount}</p>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/ui/ReviewList.tsx
+++ b/src/components/ui/ReviewList.tsx
@@ -8,9 +8,11 @@ import type { Review } from '@/types/api/common'
 export default function ReviewList({
   initialReviews,
   initialLast,
+  withMovie = true,
 }: {
   initialReviews: Review[]
   initialLast: boolean
+  withMovie?: boolean
 }) {
   const [reviews, setReviews] = useState(initialReviews)
   const [page, setPage] = useState(1)
@@ -52,7 +54,7 @@ export default function ReviewList({
     <>
       <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'>
         {reviews.map((review) => (
-          <ReviewItem key={review.reviewId} review={review} />
+          <ReviewItem key={review.reviewId} review={review} withMovie={withMovie} />
         ))}
       </div>
       {isFetching && (


### PR DESCRIPTION
## 💡 Description
- 영화 리뷰 페이지 UI를 구현
- 각 리뷰에 사용자가 좋아요를 눌렀는지 여부(`likedByUser`)를 표시


## ✨ Changes
### 영화 리뷰 페이지 UI 구현
- `MoviesReviewsPage` 구성
  - `searchParams` 기반 정렬 처리
    - 필터 버튼 클릭 시 `?sort=createdAt`, `?sort=likeCount`로 URL 변경
    - URL의 `sort` 값을 기준으로 해당 정렬 방식에 맞는 리뷰 API 호출
  - 상단 필터 버튼 클릭 시 URL 파라미터를 변경하여 정렬 기준에 맞게 리뷰 목록을 불러옴
  - `GoBackHeader` 추가: 모바일 화면에서 영화 제목과 정렬 필터 버튼 표시
  - `ReviewList` 추가: 해당 영화의 리뷰 목록 출력
  - 기존 최신 리뷰 페이지에서 사용하던 컴포넌트를 재사용
  - 무한 스크롤, 반응형 레이아웃(lg: 3열 / md: 2열 / 모바일: 1열) 그대로 지원
- `GoBackHeader` 스타일 개선
  - 버튼이 들어가도 레이아웃이 들쭉날쭉하지 않도록 `items-center` 적용
- `ReviewList` 개선
  - 기존 최신 리뷰 페이지 전용에서 → 영화 리뷰 페이지에서도 재사용 가능하게 확장
  - `withMovie`, `movieId`, `sort` props 추가
  - 초기값 설정 방식 변경
    - 기존: `useState(initialReviews)`
    - 변경: `useState([])`로 초기화한 뒤, `sort` 변경 시 `useEffect`로 `initialReviews`를 다시 반영하고 페이지를 1, `setHasMore`을 `!initialLast`로 리셋 하여 무한스크롤 정상 작동되도록 처리

### likedByUser 표시
- `ReviewList`에 `session` prop 추가:  세션이 있는 경우, 다음 페이지 요청 시 액세스 토큰을 함께 전송하여 `likedByUser` 값이 `true`/`false`로 정확하게 표시되도록 처리 (비로그인 상태에서는 `likedByUser: null`)
- `HomePage`수정: `getLatestReviews()` 호출 시 세션이 있을 경우 액세스 토큰을 포함
- `ReviewItem` 컴포넌트에서 `likedByUser`를 기반으로 하트를 강조 표시


## 📸 Screenshot
### PC 영화 리뷰 페이지 
<img width="1359" alt=" PC 영화 리뷰 페이지 " src="https://github.com/user-attachments/assets/1d7bd807-a409-4efc-a5b5-771b90279a9c" />

### 모바일 영화 리뷰 페이지
[Galaxy-S21-Ultra-localhost-5z3rca7wzd11ly.webm](https://github.com/user-attachments/assets/d25d7871-73b7-4a3e-be3e-8e4f067a350d)


### 홈페이지 최신 리뷰에서 likedByUser 표시
<img width="902" alt="스크린샷 2025-05-17 10 47 05" src="https://github.com/user-attachments/assets/e26587e1-7c98-4331-bc26-fece07bae545" />