### PR TITLE
[Feature] ReviewForm UI, 리뷰 작성/수정 페이지 UI

### DIFF
--- a/src/app/board/MyReviewSection.tsx
+++ b/src/app/board/MyReviewSection.tsx
@@ -9,11 +9,13 @@ export default function MyReviewSection({
   isSunday,
   session,
   movieId,
+  movieTitle,
   myReview,
 }: {
   isSunday: boolean
   session: Session | null
   movieId: string
+  movieTitle: string
   myReview: Review | null
 }) {
   return (
@@ -27,7 +29,7 @@ export default function MyReviewSection({
                 <ReviewItem review={myReview} withMovie={false} />
               ) : (
                 <Suspense fallback={<div className='skeleton h-18 rounded-2xl' />}>
-                  <MyReviewWrapper session={session} movieId={movieId} />
+                  <MyReviewWrapper session={session} movieId={movieId} movieTitle={movieTitle} />
                 </Suspense>
               )}
             </>

--- a/src/app/board/MyReviewWrapper.tsx
+++ b/src/app/board/MyReviewWrapper.tsx
@@ -5,11 +5,14 @@ import Link from 'next/link'
 export default async function MyReviewWrapper({
   session,
   movieId,
+  movieTitle,
 }: {
   session: Session
   movieId: string
+  movieTitle: string
 }) {
   const { status: certificationStatus } = await getCertification(session?.accessToken)
+
   return (
     <div className='bg-base-300 flex flex-col items-center gap-4 rounded-2xl p-4 md:flex-row md:justify-between md:gap-0'>
       <p className='text-center break-keep'>
@@ -19,7 +22,7 @@ export default async function MyReviewWrapper({
       {certificationStatus === 'APPROVED' ? (
         // 인증된 경우 - 리뷰 작성 안내
         <>
-          <Link className='btn btn-primary' href='/board/create'>
+          <Link className='btn btn-primary' href={`/board/create?title=${movieTitle}`}>
             인증된 리뷰 작성하기
           </Link>
         </>
@@ -32,7 +35,7 @@ export default async function MyReviewWrapper({
             </Link>
             <Link
               className='btn btn-primary btn-sm md:btn-md'
-              href={`/movies/${movieId}/reviews/create`}
+              href={`/movies/${movieId}/reviews/create?title=${movieTitle}`}
             >
               일반 리뷰 작성하기
             </Link>

--- a/src/app/board/create/actions.ts
+++ b/src/app/board/create/actions.ts
@@ -2,9 +2,11 @@
 
 import { auth } from '@/auth'
 import { createBoardReview } from '@/lib/api/discussion'
-import { redirect } from 'next/navigation'
 
-export const createBoardReviewAction = async (formData: FormData) => {
+export const createBoardReviewAction = async (
+  state: { message: string; responseReviewId: string },
+  formData: FormData
+) => {
   const session = await auth()
   if (!session) throw new Error('UNAUTHORIZED')
 
@@ -13,23 +15,23 @@ export const createBoardReviewAction = async (formData: FormData) => {
   const content = formData.get('content') as string
   const rating = formData.get('rating') as string // form에서 온거라 string임
 
-  let data
   try {
-    data = await createBoardReview(session.accessToken, {
+    const { reviewId: responseReviewId } = await createBoardReview(session.accessToken, {
       title,
       content,
       rating: Number(rating),
     })
+    return { ...state, message: 'success', responseReviewId: responseReviewId.toString() }
   } catch (error) {
     // TODO: 에러 처리 구현 (우선 분기 처리만 해둠)
     const errorCode = (error as Error).message
     switch (errorCode) {
       case 'NOT_CERTIFIED_YET':
-        throw error
+        return { ...state, message: '토론 작성 권한이 없습니다. 인증을 먼저 완료해주세요' }
       case 'MOVIE_NOT_FOUND':
-        throw error
+        return { ...state, message: '존재하지 않는 영화입니다.' }
       case 'INVALID_REVIEW_PERIOD':
-        throw error
+        return { ...state, message: '토론 작성 기간이 아닙니다. 다음 주에 새로운 영화로 만나요' }
       case 'UNEXPECTED_ERROR':
         throw new Error('UNEXPECTED_ERROR')
       // 코드 오류나 프레임워크 내부 예외 등 완전히 예상치 못한 예외 (ex. NEXT_REDIRECT, CallbackRouteError, ReferenceError 등)
@@ -39,5 +41,4 @@ export const createBoardReviewAction = async (formData: FormData) => {
         throw new Error('UNHANDLED_ERROR')
     }
   }
-  redirect(`/reviews/${data.reviewId}`)
 }

--- a/src/app/board/create/page.tsx
+++ b/src/app/board/create/page.tsx
@@ -5,18 +5,24 @@ import { createBoardReviewAction } from './actions'
 import { auth } from '@/auth'
 import { redirect } from 'next/navigation'
 import { getCertification } from '@/lib/api/certification'
+import ReviewFormSection from '@/components/layout/ReviewFormSection'
 
-export default async function BoardCreatePage() {
+export default async function BoardCreatePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ title: string }>
+}) {
   const session = await auth()
   if (!session) redirect('/login')
 
   const { status } = await getCertification(session?.accessToken)
   if (status !== 'APPROVED') redirect('/profile/watch-verification')
 
+  const { title: movieTitle } = await searchParams
+
   return (
-    <>
-      <h2>시청 인증된 사람만 접근할 수 있는 이주의 영화 리뷰 작성 페이지</h2>
-      <ReviewForm action={createBoardReviewAction} />
-    </>
+    <ReviewFormSection>
+      <ReviewForm action={createBoardReviewAction} movieTitle={movieTitle} certified={true} />
+    </ReviewFormSection>
   )
 }

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -31,6 +31,7 @@ export default async function BoardPage() {
           isSunday={isSunday}
           session={session}
           movieId={movieId}
+          movieTitle={thisWeekMovie.title}
           myReview={thisWeekMovie.myReview}
         />
         {/* 최신 리뷰 유무로 제목 옆에 더보기 버튼 유무를 결정하기 때문에 이것만 다르게 컴포넌트화 함 */}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,7 +11,7 @@
 
 @layer components {
   .container-wrapper {
-    @apply mx-auto max-w-[1440px] px-4 md:px-8 lg:px-16;
+    @apply mx-auto w-full max-w-[1440px] px-4 md:px-8 lg:px-16;
   }
 
   .overlaid-bg {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default async function RootLayout({
           <header>
             <TopNav />
           </header>
-          <main className='flex-1 pb-2 md:pb-4'>{children}</main>
+          <main className='flex flex-1 flex-col pb-2 md:pb-4'>{children}</main>
           <BottomNav />
           <Footer />
         </SessionProvider>

--- a/src/app/movies/[id]/MyReviewSection.tsx
+++ b/src/app/movies/[id]/MyReviewSection.tsx
@@ -10,6 +10,7 @@ export default function MyReviewSection({
   isSunday,
   certificationStatus,
   movieId,
+  movieTitle,
 }: {
   session: Session | null
   myReview: Review | null
@@ -17,6 +18,7 @@ export default function MyReviewSection({
   isSunday: boolean
   certificationStatus: CertificationStatus
   movieId: string
+  movieTitle: string
 }) {
   return (
     <section className='container-wrapper'>
@@ -30,7 +32,6 @@ export default function MyReviewSection({
             <ReviewItem review={myReview} withMovie={false} />
           ) : (
             // 작성한 리뷰가 없는 경우
-            // MyReviewBox으로 안내
             <div className='bg-base-300 flex flex-col items-center gap-4 rounded-2xl p-4 md:flex-row md:justify-between md:gap-0'>
               {isThisWeekMovie && !isSunday ? (
                 // 인증된 리뷰가 작성 가능한 경우 (이주의 영화이면서 일요일이 아닌 경우)
@@ -39,11 +40,11 @@ export default function MyReviewSection({
                     // 인증된 경우
                     // 리뷰 작성 안내
                     <>
-                      <p>
+                      <p className='text-center break-keep'>
                         이 영화에 대한 <span className='font-bold'>{session.user?.nickname}</span>{' '}
                         님의 생각이 궁금해요!
                       </p>
-                      <Link className='btn btn-primary' href={`/board/create`}>
+                      <Link className='btn btn-primary' href={`/board/create?title=${movieTitle}`}>
                         인증된 리뷰 작성하기
                       </Link>
                     </>
@@ -65,7 +66,7 @@ export default function MyReviewSection({
                         </Link>
                         <Link
                           className='btn btn-primary btn-sm md:btn-md'
-                          href={`/movies/${movieId}/reviews/create`}
+                          href={`/movies/${movieId}/reviews/create?title=${movieTitle}`}
                         >
                           일반 리뷰 작성하기
                         </Link>
@@ -77,13 +78,13 @@ export default function MyReviewSection({
                 // 인증된 리뷰가 작성 불가능한 경우 (이주의 영화가 아니거나 일요일인 경우)
                 // 일반 리뷰 작성 안내
                 <>
-                  <p>
+                  <p className='text-center break-keep'>
                     이 영화에 대한 <span className='font-bold'>{session.user?.nickname}</span> 님의
                     생각이 궁금해요!
                   </p>
                   <Link
                     className='btn btn-primary btn-sm md:btn-md'
-                    href={`/movies/${movieId}/reviews/create`}
+                    href={`/movies/${movieId}/reviews/create?title=${movieTitle}`}
                   >
                     리뷰 작성하기
                   </Link>

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -50,6 +50,7 @@ export default async function MoviesPage({ params }: { params: Promise<{ id: str
           isSunday={isSunday}
           certificationStatus={certificationStatus}
           movieId={id}
+          movieTitle={movie.title}
         />
         <LatestReviewSection
           latestReviews={reviews}

--- a/src/app/reviews/[id]/edit/page.tsx
+++ b/src/app/reviews/[id]/edit/page.tsx
@@ -5,27 +5,35 @@ import { updateReviewAction } from './actions'
 import { getReview } from '@/lib/api/review'
 import { auth } from '@/auth'
 import { redirect } from 'next/navigation'
+import ReviewFormSection from '@/components/layout/ReviewFormSection'
 
-export default async function ReviewsEditPage({ params }: { params: Promise<{ id: string }> }) {
+export default async function ReviewsEditPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>
+  searchParams: Promise<{ title: string }>
+}) {
   const session = await auth()
   if (!session) redirect('/login')
 
-  const { id: reviewId } = await params
-  const review = await getReview(reviewId)
+  const [{ id: reviewId }, { title: movieTitle }] = await Promise.all([params, searchParams])
 
+  const review = await getReview(reviewId)
   const action = updateReviewAction.bind(null, reviewId)
 
   return (
-    <>
-      <h2>리뷰 수정 페이지</h2>
+    <ReviewFormSection>
       <ReviewForm
         action={action}
+        movieTitle={movieTitle}
         initialValue={{
           title: review.reviewTitle,
           content: review.reviewContent,
           rating: review.rating,
         }}
+        certified={review.certified}
       />
-    </>
+    </ReviewFormSection>
   )
 }

--- a/src/app/reviews/[id]/page.tsx
+++ b/src/app/reviews/[id]/page.tsx
@@ -31,7 +31,7 @@ export default async function ReviewPage({ params }: { params: Promise<{ id: str
           <h2>{review.reviewTitle}</h2>
           {currentUserId === review.userId.toString() && (
             <>
-              <Link className='btn' href={`/reviews/${reviewId}/edit`}>
+              <Link className='btn' href={`/reviews/${reviewId}/edit?title=${review.movieTitle}`}>
                 수정
               </Link>
               {/* TODO: 삭제 전에 확인창 구현 */}

--- a/src/components/form/ReviewForm.tsx
+++ b/src/components/form/ReviewForm.tsx
@@ -1,32 +1,79 @@
+'use client'
+
+import { useActionState, useEffect } from 'react'
+import GoBackHeader from '../layout/MobileHeader/GoBackHeader'
+import Rating from '../ui/Rating'
+import { useRouter } from 'next/navigation'
+import CertifiedBadge from '../ui/CertifiedBadge'
+
 export default function ReviewForm({
   action,
+  movieTitle,
   initialValue,
+  certified,
 }: {
-  action: (formData: FormData) => void
+  action: (
+    state: { message: string; responseReviewId: string },
+    formData: FormData
+  ) => Promise<{ message: string; responseReviewId: string }>
+  movieTitle: string
   initialValue?: { title: string; content: string; rating: number }
+  certified: boolean
 }) {
   const isEdit = !!initialValue
+  const [state, formAction, isPending] = useActionState(action, {
+    message: '',
+    responseReviewId: '',
+  })
+  const router = useRouter()
+
+  useEffect(() => {
+    if (state.message === 'success') {
+      router.push(`/reviews/${state.responseReviewId}`)
+    }
+  }, [router, state])
+
   return (
-    <form action={action}>
-      <label>
-        별점
+    <form action={formAction} className='flex flex-1 flex-col'>
+      <GoBackHeader>
+        <div className='flex flex-1 items-center gap-2'>
+          <h2 className='line-clamp-1 rounded-xl text-xl font-semibold'>{movieTitle}</h2>
+          {certified && <CertifiedBadge />}
+        </div>
+        <button className='btn btn-primary rounded-xl' type='submit' disabled={isPending}>
+          {isPending ? <span className='loading loading-ring' /> : <>{isEdit ? '수정' : '작성'}</>}
+        </button>
+      </GoBackHeader>
+      <div className='mt-4 mb-3 hidden items-center justify-between md:flex'>
+        <div className='flex flex-1 items-center gap-2'>
+          <h2 className='text-xl font-semibold'>{movieTitle}</h2>
+          {certified && <CertifiedBadge />}
+        </div>
+        <button className='btn btn-primary rounded-xl' type='submit' disabled={isPending}>
+          {isPending ? <span className='loading loading-ring' /> : <>{isEdit ? '수정' : '작성'}</>}
+        </button>
+      </div>
+      {state.message !== 'success' && <p>{state.message}</p>}
+      <div className='bg-base-300 flex flex-1 flex-col rounded-2xl p-5 md:p-7'>
+        <div className='mb-5 md:mb-7'>
+          <Rating rating={initialValue?.rating} />
+        </div>
         <input
-          type='number'
-          name='rating'
-          defaultValue={initialValue?.rating}
-          step='0.5'
-          min='0.5'
-          max='5'
+          className='mb-3 border-0 text-lg font-bold focus:outline-0 md:mb-4'
+          placeholder='제목을 입력해 주세요'
+          type='text'
+          name='title'
+          defaultValue={initialValue?.title}
           required
         />
-      </label>
-
-      <input type='text' name='title' defaultValue={initialValue?.title} required />
-      <textarea name='content' defaultValue={initialValue?.content} required />
-
-      <button className='btn' type='submit'>
-        {isEdit ? '수정' : '작성'}
-      </button>
+        <textarea
+          className='flex-1 resize-none border-0 text-lg focus:outline-0'
+          placeholder={`${movieTitle}에 대한 생각을 자유롭게 공유해 주세요!`}
+          name='content'
+          defaultValue={initialValue?.content}
+          required
+        />
+      </div>
     </form>
   )
 }

--- a/src/components/layout/ReviewFormSection.tsx
+++ b/src/components/layout/ReviewFormSection.tsx
@@ -1,0 +1,9 @@
+import React, { ReactNode } from 'react'
+
+export default function ReviewFormSection({ children }: { children?: ReactNode }) {
+  return (
+    <section className='container-wrapper flex flex-1 flex-col md:px-48 lg:px-56'>
+      {children}
+    </section>
+  )
+}

--- a/src/components/ui/Rating.tsx
+++ b/src/components/ui/Rating.tsx
@@ -1,5 +1,7 @@
+'use client'
+
 import clsx from 'clsx'
-import React from 'react'
+import { useState } from 'react'
 
 export default function Rating({
   rating,
@@ -8,32 +10,79 @@ export default function Rating({
   rating?: number
   readOnly?: boolean
 }) {
+  const [selected, setSelected] = useState(rating)
+
   return (
-    <div className='rating rating-half rating-sm'>
-      {Array.from({ length: 10 }).map((_, i) => {
-        const number = (i + 1) / 2
+    <div
+      className={clsx(!readOnly && 'flex min-h-7 w-full items-center justify-between md:min-h-8')}
+    >
+      <div
+        className={clsx('rating rating-half', readOnly ? 'rating-sm' : 'rating-md md:rating-lg')}
+      >
+        {Array.from({ length: 10 }).map((_, i) => {
+          const number = (i + 1) / 2
 
-        const commonProps = {
-          className: clsx(
-            'mask mask-star-2 bg-primary',
-            number % 1 === 0 ? 'mask-half-2' : 'mask-half-1'
-          ),
-          'aria-label': `${number} star`,
-        }
+          const commonProps = {
+            className: clsx(
+              'mask mask-star-2 bg-primary',
+              number % 1 === 0 ? 'mask-half-2' : 'mask-half-1'
+            ),
+            'aria-label': `${number} star`,
+          }
 
-        return readOnly ? (
-          <div key={number} {...commonProps} aria-current={rating === number} />
-        ) : (
-          <input
-            key={number}
-            {...commonProps}
-            type='radio'
-            name='rating'
-            value={number}
-            defaultChecked={number === (rating ?? 0.5)}
-          />
-        )
-      })}
+          return readOnly ? (
+            <div key={number} {...commonProps} aria-current={rating === number} />
+          ) : (
+            <input
+              key={number}
+              {...commonProps}
+              type='radio'
+              name='rating'
+              value={number}
+              defaultChecked={number === rating}
+              onChange={() => setSelected(number)}
+              required
+            />
+          )
+        })}
+      </div>
+      {!readOnly &&
+        (() => {
+          const [emoji, text] = getRatingMessage(selected)
+          return (
+            <div className='flex items-center gap-1 md:gap-2'>
+              <p className='text-xl font-semibold md:text-2xl'>{emoji}</p>
+              <p className='text-base text-gray-400 md:text-lg'>{text}</p>
+            </div>
+          )
+        })()}
     </div>
   )
+}
+
+function getRatingMessage(rating: number | undefined): [emoji: string, message: string] {
+  switch (rating) {
+    case 5.0:
+      return ['🤩', '인생 영화네요!']
+    case 4.5:
+      return ['😍', '재밌게 보셨네요!']
+    case 4.0:
+      return ['😆', '좋은 영화네요!']
+    case 3.5:
+      return ['🙂', '무난하게 보셨네요']
+    case 3.0:
+      return ['😐', '평범했군요']
+    case 2.5:
+      return ['🙁', '아쉬웠나 봐요']
+    case 2.0:
+      return ['😨', '별로였군요']
+    case 1.5:
+      return ['😰', '실망하셨나 봐요']
+    case 1.0:
+      return ['😱', '헉...']
+    case 0.5:
+      return ['🥶', '최악이군요...']
+    default:
+      return ['🤔', '별점이 궁금해요!']
+  }
 }


### PR DESCRIPTION
## 💡 Description
- `ReviewForm` UI를 구현하고, 레이아웃 구성을 위한 `ReviewFormSection`을 추가했습니다.
- 해당 폼을 기반으로 인증된 리뷰 작성, 일반 리뷰 작성, 리뷰 수정 페이지의 UI를 완성했습니다.
- 각 페이지에서 영화 제목을 헤더에 표시하기 위해, 접근 시 `title` 쿼리 파라미터를 포함하도록 링크 구조를 수정했습니다.


## ✨ Changes

### 레이아웃 구조 개선
- `layout.tsx`의 `<main>`에 `flex flex-1 flex-col`을 적용해 콘텐츠가 유연하게 확장되도록 개선했습니다.
- `global.css`에서 `.container-wrapper`에 `w-full`을 추가해 너비가 정확하게 적용되도록 수정했습니다.
- 상위 레이아웃 구성 요소에 `flex`, `flex-col`, `flex-1`을 일관되게 적용해, `ReviewForm`이 페이지 높이를 자연스럽게 채우도록 했습니다.
- `textarea`에는 `flex-1`을 부여해 입력 영역이 가능한 최대 높이까지 확장되도록 구성했습니다.

### ReviewForm
- 별점, 제목, 내용 입력 필드를 제공합니다.
- 리뷰 작성/수정 버튼이 헤딩 우측에 위치하기 때문에, 헤더를 `ReviewForm` 내부에 포함시켰습니다.
- 별점 선택 시, 감정 이모지와 함께 피드백 메시지를 동적으로 표시합니다.
  - 예: 5.0점 → "🤩 인생 영화네요!", 2.0점 → "😨 별로였군요"
- `ReviewFormSection`이라는 래퍼 컴포넌트를 도입해, `section` 요소로 폼을 감싸는 구조로 구성했습니다.
- 영화 제목과 인증 리뷰 유무를 표시하기 위해 `movieTitle`, `certified` props 추가했습니다.

### ReviewForm props 전달 방식
#### 리뷰 수정 페이지
- `getReview()` 로 받아온 기존 리뷰 데이터를 기반으로 `movieTitle`, `certified` props 를 넘겨줍니다.

#### 영화 제목
- 인증된 리뷰 작성, 일반 리뷰 작성 페이지 진입 시 `title` 쿼리 파라미터를 포함하도록 링크를 수정했습니다.
  - ```href={/movies/${movieId}/reviews/create?title=${movieTitle}}```
  - ```href={/board/create?title=${movieTitle}}```
- `ReviewForm`에서 해당 값을 `movieTitle` prop으로 받아 표시합니다.

### 인증 여부
- 인증된 리뷰 작성 페이지에서는 `certified` prop을 `true`로 전달합니다.
- 일반 리뷰 작성 페이지에서는 `certified` prop을 `false`로 전달합니다.

## 📸 Screenshot
### 모바일
[모바일.webm](https://github.com/user-attachments/assets/d979a5b6-dff1-4a50-abde-94164138382c)

### PC
#### 일반 리뷰, 작성, 빈 폼
![일반, 작성, 빈](https://github.com/user-attachments/assets/ac4b1185-601f-41aa-b2bb-95d33a2334ac)

#### 인증된 리뷰, 수정, 채워진 폼
![인증된, 수정, 채워진](https://github.com/user-attachments/assets/e6ca6158-39d4-4615-8800-a2e0ab2443d4)