### PR TITLE
[Feature] 리뷰 상세 페이지 UI, 댓글 낙관적 UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,16 @@
     }
   }
 }
+
+@theme {
+  --animate-create-comment-success: yellow-fade-out 1s ease-in;
+
+  @keyframes yellow-fade-out {
+    0% {
+      background-color: oklch(82% 0.189 84.429 / 0.2);
+    }
+    100% {
+      background-color: transparent;
+    }
+  }
+}

--- a/src/app/reviews/[id]/CommentForm.tsx
+++ b/src/app/reviews/[id]/CommentForm.tsx
@@ -1,85 +1,222 @@
 'use client'
 
-import { useActionState, useEffect, useState } from 'react'
+import { useActionState, useEffect, useRef, useState } from 'react'
 import { createCommentAction, updateCommentAction } from './actions'
 import Link from 'next/link'
 import { useSession } from '@/providers/providers'
+import clsx from 'clsx'
+import { ClientComment, Comment } from '@/types/api/common'
 
 export default function CommentForm({
   reviewId,
   editComment,
-  onCancel,
+  isCommentPending,
+  setIsCommentPending,
+  setEditComment,
+  onCreateSuccess,
+  onEditSuccess,
+  onFail,
+  addOptimisticComment,
 }: {
   reviewId: string
-  editComment?: {
-    commentId: string
-    content: string
-  }
-  onCancel: () => void
+  editComment: Comment | null
+  isCommentPending: boolean
+  setIsCommentPending: (value: boolean) => void
+  setEditComment: (value: null) => void
+  onCreateSuccess: (newComment: Comment) => void
+  onEditSuccess: (comment: Comment) => void
+  onFail: () => void
+  addOptimisticComment: (comment: ClientComment) => void
 }) {
   const session = useSession()
   const isEdit = !!editComment
   const [content, setContent] = useState('')
+  const [isKeyboardVisible, setIsKeyboardVisible] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   const action = isEdit
-    ? updateCommentAction.bind(null, reviewId, editComment.commentId)
+    ? updateCommentAction.bind(null, reviewId, editComment.id.toString())
     : createCommentAction.bind(null, reviewId)
 
-  const [state, formAction] = useActionState(action, { message: '' })
+  const [state, formAction, isPending] = useActionState<
+    {
+      success: boolean | null
+      message: string
+      comment: Comment | null
+    },
+    FormData
+  >(action, {
+    success: null,
+    message: '',
+    comment: null,
+  })
 
   // 수정 시 기존 댓글 폼에 넣기
   useEffect(() => {
     if (editComment) {
       setContent(editComment.content)
+      inputRef.current?.focus()
     } else {
       setContent('')
     }
   }, [editComment])
 
-  // 수정, 삭제 성공시 폼 비우기
-  // TODO: eslint-disable-next-line 없어도 동작하게 구현
+  // 낙관적 렌더링
   useEffect(() => {
-    if (state?.message === '') {
+    if (!isPending) return
+    setIsCommentPending(true)
+
+    // 서버 응답을 기다리는 isPending일때 낙관적 렌더링
+    if (isEdit) {
+      // 수정 시
+      addOptimisticComment({
+        ...editComment,
+        content,
+        createdAt: '수정 중',
+        updatedAt: new Date().toISOString(),
+        optimisticStatus: 'updating',
+      })
+    } else {
+      // 작성 시
+      addOptimisticComment({
+        id: -1,
+        reviewId: Number(reviewId),
+        userId: Number(session?.user?.userId),
+        userNickname: session?.user?.nickname || '',
+        profileImageUrl: session?.user?.profileImageUrl || '',
+        content,
+        createdAt: '작성 중',
+        updatedAt: new Date().toISOString(),
+        optimisticStatus: 'creating',
+      })
+    }
+  }, [
+    addOptimisticComment,
+    content,
+    editComment,
+    isEdit,
+    isPending,
+    reviewId,
+    session?.user?.nickname,
+    session?.user?.profileImageUrl,
+    session?.user?.userId,
+    setIsCommentPending,
+  ])
+
+  // 서버 응답 받은 후
+  useEffect(() => {
+    if (state.success === null) return
+    setIsCommentPending(false)
+
+    // 성공 또는 실패
+    // 성공 시
+    if (state.success && state.comment) {
       setContent('')
-      if (editComment) {
-        onCancel()
+      // 수정 성공시
+      if (isEdit) {
+        setEditComment(null)
+        console.log('수정 댓글 응답', state.comment)
+        onEditSuccess(state.comment)
+      }
+      // 작성 성공시
+      else {
+        onCreateSuccess(state.comment)
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state])
+    // 실패 시
+    else {
+      onFail()
+    }
+
+    // 상태 초기화 (useActionState 재사용을 위해 필요)
+    state.success = null
+  }, [
+    isEdit,
+    onCreateSuccess,
+    onEditSuccess,
+    onFail,
+    setEditComment,
+    setIsCommentPending,
+    state,
+    state.message,
+  ])
+
+  // 모바일 키보드 감지
+  useEffect(() => {
+    const threshold = 150
+    const initialHeight = window.innerHeight
+
+    const handleResize = () => {
+      const heightDiff = initialHeight - window.innerHeight
+      setIsKeyboardVisible(heightDiff > threshold)
+    }
+
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
 
   return (
     <>
-      {state?.message && (
-        <div className='mt-2 text-sm text-red-500'>
-          <p>{state.message}</p>
-        </div>
-      )}
-      <form action={formAction} className='flex flex-col gap-2'>
-        <input
-          type='text'
-          name='content'
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          disabled={!session}
-          placeholder={session ? '댓글을 입력하세요' : '로그인 후 작성할 수 있어요'}
-        />
-
-        <div className='flex gap-2'>
-          {session ? (
-            <>
-              <button type='submit'>{isEdit ? '수정 완료' : '댓글 작성'}</button>
-              {isEdit && onCancel && (
-                <button type='button' onClick={onCancel} className='text-sm text-gray-500'>
-                  취소
-                </button>
+      <div
+        className={clsx(
+          'bg-base-100 container-wrapper fixed right-0 left-0 z-10 py-2 md:sticky md:px-0',
+          isKeyboardVisible
+            ? 'bottom-0' // 키보드 올라올 시 키보드 위에 붙이기
+            : 'bottom-16 md:bottom-0' // 키보드 내려갔을땐 BottomNav 위에 붙이기
+        )}
+      >
+        <form action={formAction}>
+          <div className='flex items-center gap-2'>
+            <input
+              className={clsx(
+                'bg-base-300 flex-1 rounded-2xl border-0 px-4 py-2 outline-0',
+                isCommentPending && 'text-gray-500'
               )}
-            </>
-          ) : (
-            <Link href='/login'>로그인</Link>
-          )}
-        </div>
-      </form>
+              ref={inputRef}
+              type='text'
+              name='content'
+              value={isPending ? '' : content}
+              onChange={(e) => setContent(e.target.value)}
+              disabled={!session || isPending || isCommentPending}
+              placeholder={session ? '댓글을 입력하세요' : '로그인 후 작성할 수 있어요'}
+              required
+            />
+
+            <div className='flex gap-2'>
+              {session ? (
+                <>
+                  <button
+                    className='btn btn-primary rounded-2xl'
+                    type='submit'
+                    disabled={isPending || isCommentPending}
+                  >
+                    {isPending ? (
+                      <span className='loading loading-ring' />
+                    ) : (
+                      <>{isEdit ? '수정' : '작성'}</>
+                    )}
+                  </button>
+                  {isEdit && !isPending && (
+                    <button
+                      className='btn btn-secondary rounded-2xl'
+                      type='button'
+                      onClick={() => setEditComment(null)}
+                      disabled={isCommentPending}
+                    >
+                      취소
+                    </button>
+                  )}
+                </>
+              ) : (
+                <Link href='/login'>로그인</Link>
+              )}
+            </div>
+          </div>
+          {/* TODO: 에러 토스트 메세지로 띄우기 */}
+          {state.message !== '' && <p>{state.message}</p>}
+        </form>
+      </div>
+      <div className='h-14 md:h-0' />
     </>
   )
 }

--- a/src/app/reviews/[id]/CommentForm.tsx
+++ b/src/app/reviews/[id]/CommentForm.tsx
@@ -208,7 +208,9 @@ export default function CommentForm({
                   )}
                 </>
               ) : (
-                <Link href='/login'>로그인</Link>
+                <Link className='btn btn-primary rounded-2xl' href='/login'>
+                  로그인
+                </Link>
               )}
             </div>
           </div>

--- a/src/app/reviews/[id]/CommentItem.tsx
+++ b/src/app/reviews/[id]/CommentItem.tsx
@@ -1,58 +1,157 @@
 'use client'
 
-import { CircleUserRound } from 'lucide-react'
 import Image from 'next/image'
 import { deleteCommentAction } from './actions'
-import { useActionState } from 'react'
-import { Comment } from '@/types/api/common'
+import { useActionState, useEffect } from 'react'
+import { ClientComment, Comment } from '@/types/api/common'
 import Link from 'next/link'
+import { getRelativeTime } from '@/lib/utils/date'
+import clsx from 'clsx'
 
 export default function CommentItem({
   comment,
   reviewId,
   currentUserId,
-  onEdit,
+  isCommentPending,
+  setIsCommentPending,
+  isEditComment,
+  onEditClick,
+  onDeleteSuccess,
 }: {
-  comment: Comment
+  comment: ClientComment
   reviewId: string
   currentUserId: string
-  onEdit: (commentId: string, content: string) => void
+  isCommentPending: boolean
+  setIsCommentPending: (value: boolean) => void
+  isEditComment: boolean
+  onEditClick: (comment: Comment) => void
+  onDeleteSuccess: (commentId: string) => void
 }) {
-  const isMine = currentUserId === comment.userId.toString()
+  const [state, formAction, isPending] = useActionState<{
+    success: boolean | null
+    message: string
+    commentId: string
+  }>(deleteCommentAction.bind(null, reviewId, comment.id.toString()), {
+    success: null,
+    message: '',
+    commentId: '',
+  })
+  const isMyComment = currentUserId === comment.userId.toString()
+  const isMyRecentCreatedComment =
+    isMyComment &&
+    comment.optimisticStatus === undefined &&
+    Date.now() - new Date(comment.createdAt).getTime() < 3000
 
-  const [state, formAction] = useActionState(
-    deleteCommentAction.bind(null, reviewId, comment.id.toString()),
-    { message: '' }
-  )
+  // 삭제 중
+  // CommentForm 작성, 내가 쓴 다른 댓글의 수정, 삭제 비활성화
+  useEffect(() => {
+    if (isPending) setIsCommentPending(true)
+  }, [isPending, setIsCommentPending])
 
+  // 삭제 성공
+  useEffect(() => {
+    if (state.success === null) return
+    setIsCommentPending(false)
+
+    // 성공 시
+    if (state.success) {
+      onDeleteSuccess(state.commentId)
+    }
+
+    // 삭제 시
+    // isPending이 false가 되면서 다시 원래 댓글 처럼 보임
+
+    // 상태 초기화 (useActionState 재사용 목적)
+    state.success = null
+  }, [onDeleteSuccess, setIsCommentPending, state, state.commentId, state.message, state.success])
+
+  // 삭제 시 isPending으로 낙관적 렌더링 처리
   return (
-    <li key={comment.id}>
-      <Link className='flex' href={`/profile/${comment.userId}`}>
-        {comment.profileImageUrl ? (
-          <Image src={comment.profileImageUrl} alt='프로필 사진' width={20} height={20} />
-        ) : (
-          <CircleUserRound />
-        )}
-        <p>{comment.userNickname}</p>
-      </Link>
-      <p>{comment.content}</p>
-
-      {isMine && (
-        <div className='flex gap-2'>
-          <form action={formAction}>
-            <button type='submit' className='text-sm text-red-500'>
-              삭제
-            </button>
-          </form>
-          <button
-            onClick={() => onEdit(comment.id.toString(), comment.content)}
-            className='text-sm text-blue-500'
-          >
-            수정
-          </button>
-        </div>
+    <div
+      className={clsx(
+        'overflow-hidden transition-all duration-150',
+        // 작성시 낙관적 렌더링 (배경색)
+        comment.optimisticStatus === 'creating' && 'bg-warning/20',
+        // 수정시 낙관적 렌더링 (배경색)
+        isEditComment && 'bg-success/20 opacity-50',
+        comment.optimisticStatus === 'updating' && 'opacity-100',
+        // 삭제 시 낙관적 렌더링 (배경색)
+        isPending && 'bg-error/20 opacity-50',
+        // 작성 완료 직후 실제 댓글로 전환될 때 부드러운 배경 애니메이션 처리
+        isMyRecentCreatedComment && 'animate-create-comment-success'
       )}
-      {state?.message && <p className='mt-1 text-sm text-red-500'>{state.message}</p>}
-    </li>
+    >
+      <div className='space-y-2 p-2'>
+        {/* 댓글 헤더 */}
+        <div className='flex justify-between'>
+          <Link href={`/profile/${comment.userId}`}>
+            <div className='flex items-center gap-1.5'>
+              <Image
+                className='rounded-full'
+                src={comment.profileImageUrl}
+                alt='프로필 사진'
+                width={25}
+                height={25}
+              />
+              <p className='text-sm'>{comment.userNickname}</p>
+              <p className='text-xs text-gray-400'>
+                {/* 삭제 시 낙관적 렌더링 (작성시간 대신 상태) */}
+                {isPending ? (
+                  <>
+                    삭제 중 <span className='loading loading-ring loading-xs' />
+                  </>
+                ) : (
+                  <>
+                    {/* 작성, 수정시 낙관적 렌더링 (작성시간 대신 상태) */}
+                    {!!comment.optimisticStatus ? (
+                      <>
+                        {comment.createdAt} <span className='loading loading-ring loading-xs' />
+                      </>
+                    ) : (
+                      <>
+                        {getRelativeTime(comment.createdAt)}{' '}
+                        {comment.updatedAt !== comment.createdAt && '(수정됨)'}
+                      </>
+                    )}
+                  </>
+                )}
+              </p>
+            </div>
+          </Link>
+          {isMyComment && !isEditComment && comment.optimisticStatus !== 'creating' && (
+            <div className='flex items-center gap-1'>
+              <button
+                className='btn btn-soft btn-primary btn-xs rounded-xl'
+                type='button'
+                onClick={() => onEditClick(comment)}
+                disabled={isCommentPending}
+              >
+                수정
+              </button>
+              <form action={formAction}>
+                <button
+                  className='btn btn-soft btn-secondary btn-xs rounded-xl'
+                  type='submit'
+                  disabled={isCommentPending}
+                >
+                  삭제
+                </button>
+              </form>
+            </div>
+          )}
+        </div>
+
+        {/* 댓글 내용 */}
+        <div className={clsx('bg-base-300 rounded-2xl px-4 py-2')}>
+          <p className='break-words break-keep'>{comment.content}</p>
+        </div>
+      </div>
+
+      {/* 구분선 */}
+      <hr className='text-gray-700' />
+
+      {/* TODO: 실패시 토스트 메세지 띄우기 */}
+      {state.message !== '' && <p>{state.message}</p>}
+    </div>
   )
 }

--- a/src/app/reviews/[id]/CommentList.tsx
+++ b/src/app/reviews/[id]/CommentList.tsx
@@ -2,7 +2,6 @@
 
 import { ClientComment, Comment } from '@/types/api/common'
 import CommentItem from './CommentItem'
-import { useSession } from '@/providers/providers'
 import { useEffect, useRef } from 'react'
 
 export default function CommentList({
@@ -24,7 +23,6 @@ export default function CommentList({
   onEditClick: (comment: Comment) => void
   onDeleteSuccess: (commentId: string) => void
 }) {
-  const session = useSession()
   const optimisticRef = useRef<HTMLLIElement | null>(null)
 
   useEffect(() => {
@@ -34,7 +32,6 @@ export default function CommentList({
     }
   }, [comments])
 
-  if (!session?.user) return
   return (
     <ul>
       {comments.map((comment) => (

--- a/src/app/reviews/[id]/CommentList.tsx
+++ b/src/app/reviews/[id]/CommentList.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { ClientComment, Comment } from '@/types/api/common'
+import CommentItem from './CommentItem'
+import { useSession } from '@/providers/providers'
+import { useEffect, useRef } from 'react'
+
+export default function CommentList({
+  comments,
+  reviewId,
+  currentUserId,
+  isCommentPending,
+  setIsCommentPending,
+  editingCommentId,
+  onEditClick,
+  onDeleteSuccess,
+}: {
+  comments: ClientComment[]
+  reviewId: string
+  currentUserId: string
+  isCommentPending: boolean
+  setIsCommentPending: (value: boolean) => void
+  editingCommentId: number | null
+  onEditClick: (comment: Comment) => void
+  onDeleteSuccess: (commentId: string) => void
+}) {
+  const session = useSession()
+  const optimisticRef = useRef<HTMLLIElement | null>(null)
+
+  useEffect(() => {
+    const hasCreating = comments.some((c) => c.optimisticStatus === 'creating')
+    if (hasCreating) {
+      optimisticRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+  }, [comments])
+
+  if (!session?.user) return
+  return (
+    <ul>
+      {comments.map((comment) => (
+        <li
+          key={comment.id === -1 ? 'optimistic' : comment.id}
+          ref={comment.optimisticStatus === 'creating' ? optimisticRef : null}
+        >
+          <CommentItem
+            comment={comment}
+            reviewId={reviewId}
+            currentUserId={currentUserId}
+            isCommentPending={isCommentPending}
+            setIsCommentPending={setIsCommentPending}
+            isEditComment={editingCommentId === comment.id}
+            onEditClick={onEditClick}
+            onDeleteSuccess={onDeleteSuccess}
+          />
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/app/reviews/[id]/CommentLoading.tsx
+++ b/src/app/reviews/[id]/CommentLoading.tsx
@@ -1,0 +1,11 @@
+export default function CommentLoading() {
+  return (
+    <div className='space-y-2 py-2'>
+      <div className='flex w-full items-center gap-1'>
+        <div className='skeleton h-[25px] w-[25px] shrink-0 rounded-full' />
+        <div className='skeleton h-[25px] w-full rounded-full' />
+      </div>
+      <div className='skeleton h-10 w-full rounded-2xl' />
+    </div>
+  )
+}

--- a/src/app/reviews/[id]/CommentSection.tsx
+++ b/src/app/reviews/[id]/CommentSection.tsx
@@ -1,43 +1,164 @@
 'use client'
 
-import { Comment } from '@/types/api/common'
-import { useState } from 'react'
+import { useEffect, useOptimistic, useRef, useState } from 'react'
 import CommentForm from './CommentForm'
-import CommentItem from './CommentItem'
+import CommentList from './CommentList'
+import { getComments } from '@/lib/api/comment'
+import CommentLoading from './CommentLoading'
+import { ClientComment, Comment } from '@/types/api/common'
 
 export default function CommentSection({
-  comments,
-  currentUserId,
   reviewId,
+  currentUserId,
 }: {
-  comments: Comment[]
-  currentUserId: string
   reviewId: string
+  currentUserId: string
 }) {
-  const [editComment, setEditComment] = useState<null | {
-    commentId: string
-    content: string
-  }>(null)
+  const [comments, setComments] = useState<Comment[]>([])
+  const [isInitialFetching, setIsInitialFetching] = useState(true)
+  const [isFetching, setIsFetching] = useState(false)
+  const [nextCreatedAt, setNextCreatedAt] = useState<string>('')
+  const [nextId, setNextId] = useState<number>()
+  const [hasNext, setHasNext] = useState<boolean>(true)
+  const [editComment, setEditComment] = useState<Comment | null>(null)
+  // 작성, 수정, 삭제 하는 동안 CommentForm의 작성, 내가 쓴 다른 댓글의 수정, 삭제 비활성화 용
+  const [isCommentPending, setIsCommentPending] = useState(false)
+
+  const loaderRef = useRef<HTMLDivElement | null>(null)
+  const isFetchingRef = useRef(false)
+
+  // 낙관적 렌더링 (작성, 수정)
+  // 삭제는 CommentItem에서 처리
+  const [optimisticComments, addOptimisticComment] = useOptimistic<ClientComment[], ClientComment>(
+    comments,
+    (state, newComment) => {
+      switch (newComment.optimisticStatus) {
+        // 작성시 낙관적으로 댓글 추가
+        case 'creating':
+          return [newComment, ...state]
+        // 수정시 낙관적으로 댓글 교체
+        case 'updating':
+          return state.map((comment) =>
+            comment.id === newComment.id ? { ...comment, ...newComment } : comment
+          )
+        default:
+          return state
+      }
+    }
+  )
+
+  // 성공시 호출 함수
+  // 댓글 작성
+  // Comments에 성공 응답으로 받은 댓글  추가
+  const handleCreateSuccess = (createdComment: Comment) => {
+    setComments((prev) => [createdComment, ...prev])
+  }
+
+  // 댓글 수정
+  // Comments에 성공 응답으로 받은 댓글로 교체
+  const handleEditSuccess = (updatedComment: Comment) => {
+    console.log('수정응답', updatedComment)
+    setComments((prev) =>
+      prev.map((comment) => (comment.id === updatedComment.id ? updatedComment : comment))
+    )
+  }
+
+  // 댓글 삭제
+  // Comments에 해당 댓글 삭제
+  const handleDeleteSuccess = (deletedCommentId: string) => {
+    setComments((prev) => prev.filter((comment) => comment.id !== Number(deletedCommentId)))
+  }
+
+  // 실패시 호출 함수 (작성, 수정)
+  const handleFail = () => {
+    setComments((prev) => [...prev])
+  }
+
+  // 첫 페이지 받아오기
+  useEffect(() => {
+    async function fetchInitialComments() {
+      const res = await getComments(reviewId, {
+        size: 10,
+      })
+      setComments(res.content)
+      setNextId(res.nextId)
+      setNextCreatedAt(res.nextCreatedAt)
+      setHasNext(res.hasNext)
+
+      setIsInitialFetching(false)
+    }
+
+    fetchInitialComments()
+  }, [reviewId])
+
+  // 다음 페이지 받아오기 (무한 스크롤)
+  useEffect(() => {
+    if (isInitialFetching) return
+
+    const target = loaderRef.current
+    if (!target || !hasNext) return
+
+    const observer = new IntersectionObserver(
+      async ([entry]) => {
+        if (entry.isIntersecting && !isFetchingRef.current) {
+          isFetchingRef.current = true
+          setIsFetching(true)
+          const res = await getComments(reviewId, {
+            commentId: nextId,
+            createdAt: nextCreatedAt,
+            size: 10,
+          })
+
+          setComments((prev) => [...prev, ...res.content])
+          setNextId(res.nextId)
+          setNextCreatedAt(res.nextCreatedAt)
+          setHasNext(res.hasNext)
+
+          setIsFetching(false)
+          isFetchingRef.current = false
+        }
+      },
+      {
+        threshold: 0.3,
+      }
+    )
+
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [hasNext, isInitialFetching, nextCreatedAt, nextId, reviewId])
 
   return (
-    <section>
-      <h2>댓글</h2>
-      <ul>
-        {comments.map((comment) => (
-          <CommentItem
-            key={comment.id}
-            comment={comment}
-            reviewId={reviewId}
-            currentUserId={currentUserId}
-            onEdit={(commentId, content) => setEditComment({ commentId, content })}
-          />
-        ))}
-      </ul>
-
+    <section className='container-wrapper pt-4 md:px-24 lg:px-32'>
+      {isInitialFetching ? (
+        <CommentLoading />
+      ) : (
+        <CommentList
+          comments={optimisticComments}
+          reviewId={reviewId}
+          currentUserId={currentUserId}
+          isCommentPending={isCommentPending}
+          setIsCommentPending={setIsCommentPending}
+          editingCommentId={editComment?.id ?? null}
+          onEditClick={(comment: Comment) => setEditComment(comment)}
+          onDeleteSuccess={handleDeleteSuccess}
+        />
+      )}
+      {isFetching && (
+        <div className='mt-2 w-full text-center md:mt-3'>
+          <span className='loading loading-ring loading-xl text-primary' />
+        </div>
+      )}
+      {hasNext && <div ref={loaderRef} className='h-1 w-full opacity-0' />}
       <CommentForm
         reviewId={reviewId}
-        editComment={editComment ?? undefined}
-        onCancel={() => setEditComment(null)}
+        editComment={editComment}
+        isCommentPending={isCommentPending}
+        setIsCommentPending={setIsCommentPending}
+        setEditComment={setEditComment}
+        onCreateSuccess={handleCreateSuccess}
+        onEditSuccess={handleEditSuccess}
+        onFail={handleFail}
+        addOptimisticComment={addOptimisticComment}
       />
     </section>
   )

--- a/src/app/reviews/[id]/CommentSection.tsx
+++ b/src/app/reviews/[id]/CommentSection.tsx
@@ -57,7 +57,6 @@ export default function CommentSection({
   // 댓글 수정
   // Comments에 성공 응답으로 받은 댓글로 교체
   const handleEditSuccess = (updatedComment: Comment) => {
-    console.log('수정응답', updatedComment)
     setComments((prev) =>
       prev.map((comment) => (comment.id === updatedComment.id ? updatedComment : comment))
     )

--- a/src/app/reviews/[id]/DeleteReviewButton.tsx
+++ b/src/app/reviews/[id]/DeleteReviewButton.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useActionState, useEffect } from 'react'
+import { deleteReviewAction } from './actions'
+import { useRouter } from 'next/navigation'
+
+export default function DeleteReviewButton({ reviewId }: { reviewId: string }) {
+  const [state, formAction, isPending] = useActionState<{
+    success: boolean | null
+    message: string
+  }>(deleteReviewAction.bind(null, reviewId), {
+    success: null,
+    message: '',
+  })
+  const router = useRouter()
+
+  useEffect(() => {
+    // TODO: 삭제 후 알맞은 곳으로 리디렉션하기
+    // 게시판, 영화 상세 정보 페이지, 내가 쓴 리뷰 목록 등 여러 곳에서 리뷰에 접근 할 수 있기 때문에
+    // searchParams에 from을 넣는 것도 고려
+    if (state.success) router.replace('/')
+  })
+  return (
+    <>
+      <form action={formAction}>
+        <button className='btn btn-secondary rounded-xl' type='submit' disabled={isPending}>
+          {isPending ? <span className='loading loading-ring' /> : '삭제'}
+        </button>
+      </form>
+      {state.message !== '' && <p>{state.message}</p>}
+    </>
+  )
+}

--- a/src/app/reviews/[id]/ReviewSection.tsx
+++ b/src/app/reviews/[id]/ReviewSection.tsx
@@ -1,0 +1,69 @@
+import GoBackHeader from '@/components/layout/MobileHeader/GoBackHeader'
+import { getReview } from '@/lib/api/review'
+import { Session } from 'next-auth'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import ReviewItem from '@/components/ui/ReviewItem'
+import DeleteReviewButton from './DeleteReviewButton'
+
+export default async function ReviewSection({
+  currentUserId,
+  reviewId,
+  session,
+}: {
+  currentUserId: string
+  reviewId: string
+  session: Session | null
+}) {
+  let review
+  try {
+    review = await getReview(reviewId, !!session, session?.accessToken)
+  } catch (error) {
+    if (error instanceof Error && error.message === 'REVIEW_NOT_FOUND') {
+      return notFound()
+    }
+    throw error
+  }
+
+  return (
+    <>
+      {/* 모바일 헤더 */}
+      <GoBackHeader>
+        <h2 className='flex-1 text-xl font-semibold'>리뷰</h2>
+        {currentUserId === review.userId.toString() && (
+          <div className='flex gap-2'>
+            <Link
+              className='btn btn-primary rounded-xl'
+              href={`/reviews/${reviewId}/edit?title=${review.movieTitle}`}
+            >
+              수정
+            </Link>
+            {/* TODO: 삭제 전에 확인창 구현 */}
+            <DeleteReviewButton reviewId={reviewId} />
+          </div>
+        )}
+      </GoBackHeader>
+
+      <section className='container-wrapper md:px-24 lg:px-32'>
+        {/* PC 헤더 */}
+        <div className='mt-4 mb-3 hidden items-center md:flex'>
+          <h2 className='flex-1 text-xl font-semibold'>리뷰</h2>
+          {currentUserId === review.userId.toString() && (
+            <div className='flex gap-2'>
+              <Link
+                className='btn btn-primary rounded-xl'
+                href={`/reviews/${reviewId}/edit?title=${review.movieTitle}`}
+              >
+                수정
+              </Link>
+              {/* TODO: 삭제 전에 확인창 구현 */}
+              <DeleteReviewButton reviewId={reviewId} />
+            </div>
+          )}
+        </div>
+        {/* 리뷰 */}
+        <ReviewItem review={review} withMovie={false} isDetail />
+      </section>
+    </>
+  )
+}

--- a/src/app/reviews/[id]/ReviewSectionLoading.tsx
+++ b/src/app/reviews/[id]/ReviewSectionLoading.tsx
@@ -1,0 +1,15 @@
+import GoBackHeader from '@/components/layout/MobileHeader/GoBackHeader'
+
+export default function ReviewSectionLoading() {
+  return (
+    <>
+      <GoBackHeader>
+        <h2 className='flex-1 text-xl font-semibold'>리뷰</h2>
+      </GoBackHeader>
+      <div className='container-wrapper md:px-24 lg:px-32'>
+        <h2 className='mt-4 mb-3 hidden text-xl font-semibold md:block'>리뷰</h2>
+        <div className='skeleton h-[465px] rounded-xl' />
+      </div>
+    </>
+  )
+}

--- a/src/app/reviews/[id]/actions.ts
+++ b/src/app/reviews/[id]/actions.ts
@@ -3,13 +3,12 @@
 import { auth } from '@/auth'
 import { createComment, deleteComment, updateComment } from '@/lib/api/comment'
 import { deleteReview } from '@/lib/api/review'
-import { revalidatePath } from 'next/cache'
-import { redirect } from 'next/navigation'
+import { Comment } from '@/types/api/common'
 
 // TODO: toast로 message 띄위기
 export const createCommentAction = async (
   reviewId: string,
-  state: { message: string },
+  state: { success: boolean | null; message: string; comment: Comment | null },
   formData: FormData
 ) => {
   const session = await auth()
@@ -19,15 +18,14 @@ export const createCommentAction = async (
   const content = formData.get('content') as string
 
   try {
-    await createComment(reviewId, session.accessToken, {
+    const comment = await createComment(reviewId, session.accessToken, {
       content,
     })
-    revalidatePath(`/reviews/${reviewId}`)
-    return { message: '' }
+    return { ...state, success: true, comment }
   } catch (error) {
     const errorCode = (error as Error).message
     if (errorCode === 'REVIEW_NOT_FOUND') {
-      return { ...state, message: '존재하지 않은 리뷰입니다.' }
+      return { ...state, success: false, message: '존재하지 않은 리뷰입니다.' }
     }
     throw new Error('UNHANDLED_ERROR')
   }
@@ -36,7 +34,7 @@ export const createCommentAction = async (
 export const updateCommentAction = async (
   reviewId: string,
   commentId: string,
-  state: { message: string },
+  state: { success: boolean | null; message: string; comment: Comment | null },
   formData: FormData
 ) => {
   const session = await auth()
@@ -46,21 +44,20 @@ export const updateCommentAction = async (
   const content = formData.get('content') as string
 
   try {
-    await updateComment(reviewId, commentId, { content }, session.accessToken)
-    revalidatePath(`/reviews/${reviewId}`)
-    return { message: '' }
+    const comment = await updateComment(reviewId, commentId, { content }, session.accessToken)
+    return { ...state, success: true, message: '', comment }
   } catch (error) {
     const errorCode = (error as Error).message
 
     switch (errorCode) {
       case 'REVIEW_NOT_FOUND':
-        return { ...state, message: '존재하지 않는 리뷰입니다.' }
+        return { ...state, success: false, message: '존재하지 않는 리뷰입니다.' }
       case 'COMMENT_NOT_FOUND':
-        return { ...state, message: '댓글이 존재하지 않습니다.' }
+        return { ...state, success: false, message: '댓글이 존재하지 않습니다.' }
       case 'INVALID_USER':
-        return { ...state, message: '댓글 작성자가 아닙니다.' }
+        return { ...state, success: false, message: '댓글 작성자가 아닙니다.' }
       case 'COMMENT_NOT_BELONG_TO_REVIEW':
-        return { ...state, message: '댓글이 해당 리뷰에 속하지 않습니다.' }
+        return { ...state, success: false, message: '댓글이 해당 리뷰에 속하지 않습니다.' }
       case 'UNEXPECTED_ERROR':
         throw new Error('UNEXPECTED_ERROR')
       // 코드 오류나 프레임워크 내부 예외 등 완전히 예상치 못한 예외 (ex. NEXT_REDIRECT, CallbackRouteError, ReferenceError 등)
@@ -72,21 +69,26 @@ export const updateCommentAction = async (
   }
 }
 
-export const deleteCommentAction = async (reviewId: string, commentId: string) => {
+export const deleteCommentAction = async (
+  reviewId: string,
+  commentId: string,
+  state: { success: boolean | null; message: string; commentId: string }
+) => {
   const session = await auth()
   if (!session) throw new Error('UNAUTHORIZED')
 
   try {
     await deleteComment(reviewId, commentId, session.accessToken)
-    revalidatePath(`/reviews/${reviewId}`)
-    return { message: '' }
+    return { ...state, success: true, commentId }
   } catch (error) {
     const errorCode = (error as Error).message
     switch (errorCode) {
       case 'REVIEW_NOT_FOUND':
-        throw error
+        return { ...state, success: false, message: '존재하지 않는 리뷰입니다.', commentId }
+      case 'COMMENT_NOT_FOUND':
+        return { ...state, success: false, message: '댓글이 존재하지 않습니다.', commentId }
       case 'INVALID_USER':
-        throw error
+        return { ...state, success: false, message: '작성자만 가능합니다.', commentId }
       case 'UNEXPECTED_ERROR':
         throw new Error('UNEXPECTED_ERROR')
       // 코드 오류나 프레임워크 내부 예외 등 완전히 예상치 못한 예외 (ex. NEXT_REDIRECT, CallbackRouteError, ReferenceError 등)
@@ -98,19 +100,23 @@ export const deleteCommentAction = async (reviewId: string, commentId: string) =
   }
 }
 
-export const deleteReviewAction = async (reviewId: string) => {
+export const deleteReviewAction = async (
+  reviewId: string,
+  state: { success: boolean | null; message: string }
+) => {
   const session = await auth()
   if (!session) throw new Error('UNAUTHORIZED')
 
   try {
     await deleteReview(reviewId, session.accessToken)
+    return { ...state, success: true }
   } catch (error) {
     const errorCode = (error as Error).message
     switch (errorCode) {
       case 'REVIEW_NOT_FOUND':
-        throw error
+        return { ...state, success: false, message: '존재하지 않는 리뷰입니다.' }
       case 'INVALID_USER':
-        throw error
+        return { ...state, success: false, message: '작성자만 가능합니다.' }
       case 'UNEXPECTED_ERROR':
         throw new Error('UNEXPECTED_ERROR')
       // 코드 오류나 프레임워크 내부 예외 등 완전히 예상치 못한 예외 (ex. NEXT_REDIRECT, CallbackRouteError, ReferenceError 등)
@@ -120,9 +126,4 @@ export const deleteReviewAction = async (reviewId: string) => {
         throw new Error('UNHANDLED_ERROR')
     }
   }
-
-  // TODO: 삭제 후 알맞은 곳으로 리디렉션하기
-  // 게시판, 영화 상세 정보 페이지, 내가 쓴 리뷰 목록 등 여러 곳에서 리뷰에 접근 할 수 있기 때문에
-  // searchParams에 from을 넣는 것도 고려
-  redirect('/')
 }

--- a/src/app/reviews/[id]/page.tsx
+++ b/src/app/reviews/[id]/page.tsx
@@ -1,78 +1,24 @@
 export const dynamic = 'force-dynamic'
 
-import { getReview } from '@/lib/api/review'
-import { CircleUserRound } from 'lucide-react'
-import Image from 'next/image'
-import Link from 'next/link'
 import { auth } from '@/auth'
+import { Suspense } from 'react'
 import CommentSection from './CommentSection'
-import { notFound } from 'next/navigation'
-import { deleteReviewAction } from './actions'
-import LikeButton from '@/components/ui/LikeButton'
+import ReviewSection from './ReviewSection'
+import ReviewSectionLoading from './ReviewSectionLoading'
 
 export default async function ReviewPage({ params }: { params: Promise<{ id: string }> }) {
   const [session, { id: reviewId }] = await Promise.all([auth(), params])
   const currentUserId = session?.user?.userId.toString() || ''
 
-  let review
-  try {
-    review = await getReview(reviewId, !!session, session?.accessToken)
-  } catch (error) {
-    if (error instanceof Error && error.message === 'REVIEW_NOT_FOUND') {
-      return notFound()
-    }
-    throw error
-  }
-
   return (
     <>
-      <section className='flex'>
-        <div className='flex-1'>
-          <h2>{review.reviewTitle}</h2>
-          {currentUserId === review.userId.toString() && (
-            <>
-              <Link className='btn' href={`/reviews/${reviewId}/edit?title=${review.movieTitle}`}>
-                수정
-              </Link>
-              {/* TODO: 삭제 전에 확인창 구현 */}
-              <form action={deleteReviewAction.bind(null, reviewId)}>
-                <button className='btn'>삭제</button>
-              </form>
-            </>
-          )}
-          <Link className='flex' href={`/profile/${review.userId}`}>
-            {review.profileImageUrl ? (
-              <Image src={`${review.profileImageUrl}`} alt='프로필 사진' width={20} height={20} />
-            ) : (
-              <CircleUserRound />
-            )}
-            <p>{review.nickname}</p>
-          </Link>
-          <p>별점: {review.rating}</p>
-          <p>{review.reviewContent}</p>
-        </div>
-        <div>
-          <Link href={`/movies/${review.tmdbId}`}>
-            <Image
-              src={`https://image.tmdb.org/t/p/original${review.posterPath}`}
-              width={200}
-              height={300}
-              alt='포스터'
-            />
-            <p>{review.movieTitle}</p>
-          </Link>
-        </div>
-      </section>
-      <LikeButton
-        likedByUser={review.likedByUser}
-        likeCount={review.likeCount}
-        reviewId={reviewId}
-      />
-      <CommentSection
-        comments={review.comments}
-        currentUserId={currentUserId}
-        reviewId={reviewId}
-      />
+      {/* 리뷰 헤더 & 섹션 */}
+      {/* 헤더에서 review가 필요하므로 같이 로당 처리 */}
+      <Suspense fallback={<ReviewSectionLoading />}>
+        <ReviewSection currentUserId={currentUserId} reviewId={reviewId} session={session} />
+      </Suspense>
+      {/* 댓글 섹션 */}
+      <CommentSection reviewId={reviewId} currentUserId={currentUserId} />
     </>
   )
 }

--- a/src/components/ui/LikeButton.tsx
+++ b/src/components/ui/LikeButton.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { toggleLikeAction } from '@/lib/actions/like'
+import clsx from 'clsx'
+import { Heart } from 'lucide-react'
 import { useActionState } from 'react'
 
 export default function LikeButton({
@@ -20,10 +22,10 @@ export default function LikeButton({
 
   return (
     <form action={formAction}>
-      <button className='btn' disabled={likedByUser === null}>
-        {state.likedByUser ? '❤️' : '🤍'}
+      <button className='flex gap-1' disabled={likedByUser === null}>
+        <Heart className={clsx(state.likedByUser && 'fill-primary stroke-primary')} />
+        <p>{state.likeCount}</p>
       </button>
-      {state.likeCount}
       {state.message && <p>좋아요 실패</p>}
     </form>
   )

--- a/src/components/ui/ReviewItem.tsx
+++ b/src/components/ui/ReviewItem.tsx
@@ -6,46 +6,50 @@ import Rating from './Rating'
 import { Heart, MessageCircle } from 'lucide-react'
 import clsx from 'clsx'
 import CertifiedBadge from './CertifiedBadge'
+import LikeButton from './LikeButton'
 
 export default function ReviewItem({
   review,
   withMovie = true,
+  isDetail = false,
 }: {
   review: Review
   withMovie?: boolean
+  isDetail?: boolean
 }) {
-  return (
-    <Link href={`/reviews/${review.reviewId}`}>
-      <div
-        className={clsx(
-          'bg-base-300 rounded-xl p-4',
-          withMovie ? 'space-y-2' : 'flex h-56 flex-col gap-3'
-        )}
-      >
-        {/* 상단 유저 정보 */}
-        <div className='flex items-center justify-between'>
-          <div className='flex items-center gap-2'>
-            <Image
-              src={`${review.profileImageUrl}`}
-              alt='프로필 사진'
-              width={33}
-              height={33}
-              className='aspect-square rounded-full'
-            />
-            <div>
-              <div className='flex items-center gap-1'>
-                <p className='text-sm'>{review.nickname}</p>
-                {review.certified && <CertifiedBadge />}
-              </div>
-              <p className='text-xs text-gray-500'>{getRelativeTime(review.createdAt)}</p>
+  const content = (
+    <div
+      className={clsx(
+        'bg-base-300 rounded-xl p-4',
+        withMovie ? 'space-y-3' : 'flex flex-col gap-3',
+        withMovie === false && isDetail === false && 'h-64'
+      )}
+    >
+      {/* 상단 유저 정보 */}
+      <div className='flex items-center justify-between'>
+        <div className='flex items-center gap-2'>
+          <Image
+            src={`${review.profileImageUrl}`}
+            alt='프로필 사진'
+            width={33}
+            height={33}
+            className='aspect-square rounded-full'
+          />
+          <div>
+            <div className='flex items-center gap-1'>
+              <p className='text-sm'>{review.nickname}</p>
+              {review.certified && <CertifiedBadge />}
             </div>
+            <p className='text-xs text-gray-500'>{getRelativeTime(review.createdAt)}</p>
           </div>
-          <Rating rating={review.rating} readOnly={true} />
         </div>
-        {/* 중간 영화 포스터 & 리뷰 */}
-        <div className={clsx(withMovie ? 'flex gap-3' : 'flex-1 space-y-1 overflow-hidden')}>
-          {withMovie && (
-            <div className='relative aspect-[2/3] flex-1 shrink-0'>
+        <Rating rating={review.rating} readOnly={true} />
+      </div>
+      {/* 중간 영화 포스터 & 리뷰 */}
+      <div className={clsx(withMovie ? 'flex gap-3' : 'flex-1 space-y-1 overflow-hidden')}>
+        {withMovie && (
+          <div className='flex flex-1 flex-col gap-1.5'>
+            <div className='relative aspect-[2/3] shrink-0'>
               <Image
                 src={`https://image.tmdb.org/t/p/w500${review.posterPath}`}
                 alt={`${review.movieTitle} 포스터`}
@@ -53,29 +57,64 @@ export default function ReviewItem({
                 className='rounded-lg object-cover'
               />
             </div>
-          )}
-          <div className={clsx(withMovie ? 'flex-2 space-y-1 overflow-hidden' : 'space-y-1')}>
-            <p className='line-clamp-1 text-lg font-bold'>{review.reviewTitle}</p>
-            <p className='line-clamp-3 break-words'>{review.reviewContent}</p>
+            <p className='line-clamp-1 text-center'>{review.movieTitle}</p>
           </div>
-        </div>
-        {/* 하단 영화 제목 & 좋아요, 댓글 */}
-        <div className={clsx('flex', withMovie && 'justify-between gap-3')}>
-          {withMovie && (
-            <p className='truncate overflow-hidden whitespace-nowrap'>{review.movieTitle}</p>
+        )}
+        <div className={clsx('space-y-2', withMovie && 'flex-2 overflow-hidden')}>
+          {isDetail && (
+            <Link href={`/movies/${review.tmdbId}`}>
+              <div className='flex flex-col items-center gap-3 py-2 md:float-left md:mr-6 md:py-0'>
+                <Image
+                  className='rounded-2xl'
+                  src={`https://image.tmdb.org/t/p/w500${review.posterPath}`}
+                  alt={`${review.movieTitle} 포스터`}
+                  width={200}
+                  height={300}
+                />
+                <p>{review.movieTitle}</p>
+              </div>
+            </Link>
           )}
-          <div className='flex gap-3'>
-            <div className='flex gap-1'>
-              <Heart className={clsx(review.likedByUser && 'fill-primary stroke-primary')} />
-              <p>{review.likeCount}</p>
-            </div>
-            <div className='flex gap-1'>
-              <MessageCircle />
-              <p>{review.commentCount}</p>
-            </div>
+          <p
+            className={clsx(
+              'text-lg font-bold break-words',
+              isDetail ? 'whitespace-pre-wrap' : 'line-clamp-1'
+            )}
+          >
+            {review.reviewTitle}
+          </p>
+          <p className={clsx('break-words', isDetail ? 'whitespace-pre-wrap' : 'line-clamp-4')}>
+            {review.reviewContent}
+          </p>
+        </div>
+      </div>
+      <hr className='text-gray-600' />
+      {/* 하단 영화 제목 & 좋아요, 댓글 */}
+      <div className={clsx('flex', withMovie && 'justify-between gap-3')}>
+        <div className={clsx('flex flex-2 gap-3', withMovie ? 'justify-start' : 'justify-start')}>
+          <div className='flex gap-1'>
+            {isDetail ? (
+              <LikeButton
+                likedByUser={review.likedByUser}
+                likeCount={review.likeCount}
+                reviewId={review.reviewId.toString()}
+              />
+            ) : (
+              <>
+                <Heart className={clsx(review.likedByUser && 'fill-primary stroke-primary')} />
+                <p>{review.likeCount}</p>
+              </>
+            )}
+          </div>
+          <div className='flex gap-1'>
+            <MessageCircle />
+            <p>{review.commentCount}</p>
           </div>
         </div>
       </div>
-    </Link>
+    </div>
+  )
+  return (
+    <>{isDetail ? <>{content}</> : <Link href={`/reviews/${review.reviewId}`}>{content}</Link>}</>
   )
 }

--- a/src/types/api/comment.ts
+++ b/src/types/api/comment.ts
@@ -1,4 +1,4 @@
-import { BasePaginationParams, Comment, PaginatedResponse } from './common'
+import { Comment, PaginationParamsWithSort } from './common'
 
 // API 타입
 
@@ -9,9 +9,17 @@ export type UpdateCommentResponse = Comment
 // 댓글 삭제
 
 // 특정 리뷰에 달린 댓글 조회
-export type GetCommentsParams = BasePaginationParams
+export type GetCommentsParams = PaginationParamsWithSort<'CreatedAt'> & {
+  createdAt?: string
+  commentId?: number
+}
 
-export type GetCommentsResponse = PaginatedResponse<Comment>
+export interface GetCommentsResponse {
+  content: Comment[]
+  nextCreatedAt: string
+  nextId: number
+  hasNext: boolean
+}
 
 // 댓글 작성
 export type CreateCommentParams = GetCommentsParams

--- a/src/types/api/common.ts
+++ b/src/types/api/common.ts
@@ -2,7 +2,7 @@ export interface BaseUser {
   userId: number
   email: string
   nickname: string
-  profileImageUrl: string | null
+  profileImageUrl: string
   role: 'USER' | 'ADMIN'
   accessToken: string
   refreshToken: string

--- a/src/types/api/common.ts
+++ b/src/types/api/common.ts
@@ -53,7 +53,6 @@ export interface Review {
   movieTitle: string
   posterPath: string
   certified: boolean
-  comments: Comment[]
 }
 
 export interface Comment {
@@ -66,6 +65,11 @@ export interface Comment {
   createdAt: string
   updatedAt: string
 }
+
+export type ClientComment = Comment & {
+  optimisticStatus?: 'creating' | 'updating' | 'deleting'
+}
+
 export type ImgRequest = FormData
 
 export type ReviewSortField = 'createdAt' | 'likeCount' | 'rating'

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -18,7 +18,7 @@ export declare module '@auth/core/jwt' {
   interface JWT {
     userId: number
     nickname: string
-    profileImageUrl: string | null
+    profileImageUrl: string
     role: 'USER' | 'ADMIN'
     accessToken: string
     refreshToken: string

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -2,7 +2,7 @@ declare module 'next-auth' {
   interface User {
     userId: number
     nickname: string
-    profileImageUrl: string | null
+    profileImageUrl: string
     role: 'USER' | 'ADMIN'
     accessToken: string
     refreshToken: string


### PR DESCRIPTION
## 💡 Description
- 리뷰 상세 페이지 UI를 구현했습니다.
- 댓글 섹션 UI를 구현하고, 낙관적 렌더링을 적용했습니다.
- `LikeButton` UI를 개선했습니다.
- 사용자 관련 타입 정의를 정리하고 불필요한 null 처리를 제거했습니다.

## ✨ Changes
### 리뷰 섹션
- `ReviewSection` 컴포넌트로 구현했으며, 리뷰 헤더(제목 + 수정/삭제 버튼 포함)까지 구성되어 있습니다.
- 서버 컴포넌트이며, `Suspense`를 사용해 로딩 중에는 `ReviewSectionLoading`을 표시합니다.
  - `ReviewSectionLoading`에도 헤더 구조를 포함하여 레이아웃 변경 없이 로딩 UX를 제공합니다.
- 리뷰 본문은 `ReviewItem` 컴포넌트를 사용해 렌더링하며, 해당 컴포넌트에 여러 개선을 적용했습니다:
  - `isDetail` prop을 추가해 상세 페이지용 스타일과 기능을 지원합니다.
  - 리뷰 하단 영화 제목 + 좋아요와 댓글 수 영역에서, 좋아요와 댓글 수를 따로 분리해 하단 왼쪽에 정렬되도록 UI 수정했습니다.
  - PC에서는 포스터와 제목을 왼쪽에 배치(`float-left`), 모바일에서는 세로로(`flex-col`) 정렬되도록 반응형 적용했습니다.
  - 상세 페이지에서 좌우 여백을 조정해 `ReviewForm`과 너비를 맞췄습니다.
  - 영화 제목과 포스터 클릭 시 영화 상세 페이지로 이동하도록 수정. (기존 리스트나 캐러셀에서는 전체 영역이 링크)
- 리뷰 삭제는 클라이언트 컴포넌트인 `DeleteReviewButton`을 통해 처리합니다.
- 리뷰 객체에서 댓글 관련 일부 속성을 제거하고, 타입 정의를 정리했습니다.

### 댓글섹션
- 기존의 오프셋 기반 페이지네이션을 커서 기반으로 전환해 무한 스크롤과 낙관적 렌더링에 안정적으로 대응할 수 있도록 개선했습니다.
- `Comment` 타입에 `optimisticStatus` 필드를 추가한 `ClientComment` 타입을 새로 정의해, 작성/수정 상태를 클라이언트에서 명확히 표현할 수 있게 했습니다.
- `useActionState`의 `state` 구조를 개선했습니다:
  - 작성/수정: 서버 응답에서 `success`와 `comment`를 받아, 성공 시 상태 반영
  - 삭제: `success`와 `commentId`를 받아 해당 댓글을 클라이언트에서 제거
- `CommentSection`에서는 댓글 상태(`comments`)를 관리하고, `useOptimistic` 훅을 사용해 작성/수정 낙관적 렌더링을 적용했습니다.
  - 삭제의 경우에는 `CommentItem`에서 `isPending` 상태를 감지하여 처리하는 방식이 더 간단하고 직관적이어서, 별도로 `useOptimistic`을 사용하지 않았습니다.
- 낙관적 렌더링 흐름
  - `CommentForm`에서 댓글 작성/수정이 시작되면, `isPending`을 감지해 `optimisticStatus`를 포함한 임시 댓글을 `addOptimisticComment()`로 추가합니다.
  - 작업 완료 후 `state.success` 값에 따라:
    - `true`: 서버 응답으로 받은 실제 댓글(`state.comment`)을 `setComments()`로 반영합니다.
    - `false`: 실패한 경우, 기존 상태를 유지하여 롤백 처리합니다.
  - 삭제는 `CommentItem` 내에서 `isPending` 상태를 감지해 해당 댓글을 낙관적으로 숨기고, 성공 시 완전히 제거합니다.
- 작성 성공 후 부드러운 전환 UX
  - 사용자가 작성한 댓글이면서 낙관적 댓글이 아니고 생성된 지 3초 이내인 경우에는 배경색이 서서히 사라지는 **yellow fade-out 애니메이션**을 적용해 부드럽게 전환되도록 했습니다.
  - 이를 통해 “댓글 작성이 완료되었음”을 시각적으로 자연스럽게 인지할 수 있도록 UX를 개선했습니다.
- 작성/수정/삭제 중 중복 동작 방지
  - 댓글 작성/수정/삭제 중에는 다른 댓글의 조작을 막기 위해, `isCommentPending` 상태를 `CommentSection`에서 관리하고 하위 컴포넌트에 전달하여 중복 동작을 방지했습니다.
- `CommentForm` UI
  - 모바일에서는 댓글 입력 폼이 `fixed`로 화면 하단에 고정되며, `BottomNav` 위에 위치합니다.
  - 키보드가 올라올 경우에는 `BottomNav`가 사라지고, 댓글 폼은 모바일 키보드 바로 위에 자연스럽게 붙도록 처리했습니다.
  - PC에서는 댓글 입력 폼이 하단에 `sticky`로 고정되며, 스크롤 시 `footer`를 가리지 않도록 배치되어 있습니다.
  - 작성과 수정 모두 동일한 단일 폼 컴포넌트를 재사용하며, 수정 시에는 기존 댓글 내용을 불러와 그대로 편집할 수 있습니다.

### `LikeButton` UI 수정
- 기존 이모지 기반에서 `lucide-react`의 `Heart` 아이콘으로 변경해 디자인 일관성을 맞췄습니다.

### 사용자 관련 타입 변경
- 기본 프로필 이미지를 서버에서 항상 제공하므로 `profileImageUrl` 타입을 `string | null` → `string`으로 변경했습니다.


## 📸 Screenshot
### 댓글 섹션
- PC와 동일한 레이아웃이므로 모바일 화면만 제공합니다.

[댓글 모바일.webm](https://github.com/user-attachments/assets/05fc8341-9cc8-4b56-bad4-534940511ec9)


### 리뷰 페이지
#### PC
![리뷰 PC](https://github.com/user-attachments/assets/df7b7a7a-5cf0-4c13-9e25-26ed4b2d6c33)

#### 모바일 
![리뷰 모바일 app](https://github.com/user-attachments/assets/28d55dd8-8196-4c76-a486-071610e9b5ed)