### PR TITLE
[Fix] 실제 모바일 환경에서 댓글 폼, 리뷰 폼 버그 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,8 +7,8 @@
   default: false;
   prefersdark: true;
   color-scheme: 'dark';
-  --color-base-100: oklch(15% 0 0);
-  --color-base-200: oklch(7.5% 0 0);
+  --color-base-100: oklch(16% 0 0);
+  --color-base-200: oklch(8% 0 0);
   --color-base-300: oklch(0% 0 0);
   --color-base-content: oklch(97.807% 0.029 256.847);
   --color-primary: oklch(0.5814 0.2349 27.99);

--- a/src/app/reviews/[id]/CommentForm.tsx
+++ b/src/app/reviews/[id]/CommentForm.tsx
@@ -153,23 +153,21 @@ export default function CommentForm({
     <>
       <div
         className={clsx(
-          'bg-base-100 container-wrapper fixed right-0 left-0 z-10 py-2 md:sticky md:px-0',
+          'container-wrapper bg-base-100 fixed right-0 left-0 z-10 w-full py-2 md:sticky md:px-0',
           isKeyboardVisible ? 'bottom-0' : 'bottom-16 md:bottom-0'
         )}
       >
         <form action={formAction}>
-          <div className='flex items-center gap-2'>
-            <input
-              {...register('content')}
-              className={clsx(
-                'bg-base-300 flex-1 rounded-full border-0 px-4 py-2 outline-0',
-                isCommentPending && 'text-gray-500'
-              )}
-              type='text'
-              disabled={!session || isPending || isCommentPending}
-              placeholder={session ? '댓글을 입력하세요' : '로그인 후 작성할 수 있어요'}
-            />
-
+          <div className='flex gap-2'>
+            <label className='bg-base-300 flex-1 rounded-full px-4 py-2'>
+              <input
+                {...register('content')}
+                className={clsx('w-full border-0 outline-0', isCommentPending && 'text-gray-500')}
+                type='text'
+                disabled={!session || isPending || isCommentPending}
+                placeholder={session ? '댓글을 입력하세요' : '로그인 후 작성할 수 있어요'}
+              />
+            </label>
             <div className='flex gap-2'>
               {session ? (
                 <>

--- a/src/components/form/ReviewForm.tsx
+++ b/src/components/form/ReviewForm.tsx
@@ -48,11 +48,9 @@ export default function ReviewForm({
     },
   })
 
-  const title = watch('title') ?? ''
-  const titleLength = title.length
   const content = watch('content') ?? ''
   const contentLength = content.length
-  watch('rating')
+  watch(['rating', 'title'])
 
   useEffect(() => {
     if (state.code === '') return
@@ -105,7 +103,6 @@ export default function ReviewForm({
             type='text'
             maxLength={60}
           />
-          <span className='tracking-tighter text-gray-400'>{titleLength} / 60</span>
         </label>
         <textarea
           {...register('content')}


### PR DESCRIPTION
## 💡 Description
- 실제 모바일 환경에서 댓글 폼 넘치는 버그 수정
- 실제 모바일 환경에서 리뷰 폼의 제목 최대 글자 수 넘치는 버그 수정

## ✨ Changes
- 댓글 폼 컨테이너의 너비 조절 및 래퍼로 `label`요소 추가
- 리뷰 폼의 제목 최대 글자 수 안보이게 제거
- 가시성을 위해 테마 대비 조절

## 📸 Screenshot
### 댓글 폼
![댓글폼](https://github.com/user-attachments/assets/1c9df856-4733-434f-82c8-ec1ff704c0c7)

### 리뷰 폼
![리뷰폼](https://github.com/user-attachments/assets/b52a6daa-ba74-4b20-b608-321f811a9edf)
