### PR TITLE
[Style] 댓글 border-radius 수정

### DIFF
--- a/src/app/reviews/[id]/CommentItem.tsx
+++ b/src/app/reviews/[id]/CommentItem.tsx
@@ -150,7 +150,7 @@ export default function CommentItem({
         </div>
 
         {/* 댓글 내용 */}
-        <div className={clsx('bg-base-300 rounded-full px-4 py-2')}>
+        <div className={clsx('bg-base-300 rounded-3xl px-4 py-2')}>
           <p className='break-words break-keep'>{comment.content}</p>
         </div>
       </div>


### PR DESCRIPTION
## 💡 Description
- 댓글이 한 줄일 때는 `rounded-full`이 자연스럽지만, 여러 줄일 경우 모양이 어색해지는 문제를 개선

## ✨ Changes
- `CommentItem`의 `rounded-full`을 `rounded-3xl`로 수정

## 📸 Screenshot
<img width="475" alt="스크린샷 2025-07-03 18 54 59" src="https://github.com/user-attachments/assets/07d69c80-8166-4d15-90eb-ff785fb34274" />