### PR TITLE
[Refactor] 투표 결과 주입 로직 제거

### DIFF
--- a/src/app/admin/(admin)/CreateVoteButton.tsx
+++ b/src/app/admin/(admin)/CreateVoteButton.tsx
@@ -1,27 +1,17 @@
 'use client'
 
-import { useActionState, useEffect, useState } from 'react'
+import { useActionState, useEffect } from 'react'
 import { createVoteAction } from './actions'
-import VoteCard from '../../board/VoteCard'
-import { Movie } from '@/types/api/movie'
 import { COMMON_CODES, COMMON_MESSAGES } from '@/constants/messages/common'
 import toast from 'react-hot-toast'
 
 export default function CreateVoteButton() {
-  const [isCreated, setIsCreated] = useState(false)
-  const [voteOptions, setVoteOptions] = useState<Movie[]>([])
   const [state, formAction, isPending] = useActionState(createVoteAction, {
-    voteOptions: [],
     code: '',
   })
 
   useEffect(() => {
     if (state.code === '') return
-
-    if (state.code === COMMON_CODES.SUCCESS) {
-      setVoteOptions(state.voteOptions)
-      setIsCreated(true)
-    }
 
     if (state.code === COMMON_CODES.NETWORK_ERROR) {
       toast.error(COMMON_MESSAGES.NETWORK_ERROR!)
@@ -29,16 +19,10 @@ export default function CreateVoteButton() {
   }, [state])
 
   return (
-    <>
-      {isCreated ? (
-        <VoteCard voteOptions={voteOptions} readOnly />
-      ) : (
-        <form action={formAction}>
-          <button className='btn btn-primary' disabled={isPending}>
-            {isPending ? <span className='loading loading-ring' /> : '투표 생성'}
-          </button>
-        </form>
-      )}
-    </>
+    <form action={formAction}>
+      <button className='btn btn-primary' disabled={isPending}>
+        {isPending ? <span className='loading loading-ring' /> : '투표 생성'}
+      </button>
+    </form>
   )
 }

--- a/src/app/admin/(admin)/actions.ts
+++ b/src/app/admin/(admin)/actions.ts
@@ -2,22 +2,18 @@
 
 import { auth } from '@/auth'
 import { COMMON_CODES } from '@/constants/messages/common'
-import { getMovie } from '@/lib/api/movie'
 import { createVote } from '@/lib/api/vote'
-import { Movie } from '@/types/api/movie'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 
-export const createVoteAction = async (state: { voteOptions: Movie[]; code: string }) => {
+export const createVoteAction = async (state: { code: string } = { code: '' }) => {
   const session = await auth()
   if (!session) redirect('/login')
 
   try {
-    const { tmdbIds } = await createVote(session.accessToken)
-    const voteOptions = await Promise.all(tmdbIds.map((id) => getMovie(id.toString())))
-
+    await createVote(session.accessToken)
     revalidatePath('/admin')
-    return { ...state, voteOptions, code: COMMON_CODES.SUCCESS as string }
+    return { ...state }
   } catch (error) {
     const errorCode = (error as Error).message
     switch (errorCode) {
@@ -25,7 +21,7 @@ export const createVoteAction = async (state: { voteOptions: Movie[]; code: stri
         return { ...state, code: errorCode }
       default:
         console.error(error)
-        throw new Error('UNHANDLED_ERROR')
+        throw new Error(COMMON_CODES.UNHANDLED_ERROR)
     }
   }
 }

--- a/src/app/board/VoteCard.tsx
+++ b/src/app/board/VoteCard.tsx
@@ -6,8 +6,6 @@ import { participateVoteAction } from './actions'
 import Link from 'next/link'
 import { Movie } from '@/types/api/movie'
 import { ChevronRight } from 'lucide-react'
-import VoteResultCard from './VoteResultCard'
-import { VoteResultWithMovie } from '@/types/api/vote'
 import { COMMON_CODES, COMMON_MESSAGES } from '@/constants/messages/common'
 import toast from 'react-hot-toast'
 
@@ -18,10 +16,7 @@ export default function VoteCard({
   voteOptions: Movie[]
   readOnly?: boolean
 }) {
-  const [isVoted, setIsVoted] = useState(false)
-  const [voteResults, setVoteResults] = useState<VoteResultWithMovie[]>([])
   const [state, formAction, isPending] = useActionState(participateVoteAction, {
-    voteResults: [],
     code: '',
   })
   const [selected, setSelected] = useState<number>()
@@ -29,82 +24,70 @@ export default function VoteCard({
   useEffect(() => {
     if (state.code === '') return
 
-    if (state.code === COMMON_CODES.SUCCESS) {
-      setIsVoted(true)
-      setVoteResults(state.voteResults)
-    }
-
     if (state.code === COMMON_CODES.NETWORK_ERROR) {
       toast.error(COMMON_MESSAGES.NETWORK_ERROR!)
     }
   }, [state])
 
   return (
-    <>
-      {isVoted ? (
-        <VoteResultCard voteResults={voteResults} withTitle={false} />
-      ) : (
-        <form action={formAction}>
-          <ul className='grid grid-cols-1 gap-4 px-1 pt-6 md:grid-cols-2 lg:grid-cols-3'>
-            {voteOptions.map((voteOption) => (
-              <li key={voteOption.id}>
-                <label>
-                  <input
-                    type='radio'
-                    name='tmdbId'
-                    value={voteOption.id}
-                    className='peer hidden'
-                    onChange={() => setSelected(voteOption.id)}
-                    disabled={readOnly}
+    <form action={formAction}>
+      <ul className='grid grid-cols-1 gap-4 px-1 pt-6 md:grid-cols-2 lg:grid-cols-3'>
+        {voteOptions.map((voteOption) => (
+          <li key={voteOption.id}>
+            <label>
+              <input
+                type='radio'
+                name='tmdbId'
+                value={voteOption.id}
+                className='peer hidden'
+                onChange={() => setSelected(voteOption.id)}
+                disabled={readOnly}
+              />
+              <div className='bg-base-100 peer-checked:ring-primary flex gap-4 rounded-lg p-4 peer-checked:ring-2'>
+                <div className='relative aspect-2/3 flex-2 overflow-hidden rounded-lg'>
+                  <Image
+                    src={`https://image.tmdb.org/t/p/w500${voteOption.poster_path}`}
+                    alt='포스터'
+                    fill
                   />
-                  <div className='bg-base-100 peer-checked:ring-primary flex gap-4 rounded-lg p-4 peer-checked:ring-2'>
-                    <div className='relative aspect-2/3 flex-2 overflow-hidden rounded-lg'>
-                      <Image
-                        src={`https://image.tmdb.org/t/p/w500${voteOption.poster_path}`}
-                        alt='포스터'
-                        fill
-                      />
-                    </div>
-                    <div className='flex aspect-square flex-3 flex-col justify-between'>
-                      <div className='space-y-1'>
-                        <p className='text-lg font-semibold break-keep md:text-xl'>
-                          {voteOption.title}
-                        </p>
-                        <p className='text-sm break-keep text-gray-400'>
-                          {voteOption.release_date.slice(0, 4)} ·{' '}
-                          {voteOption.genre_names.join(' / ')}
-                          {!!voteOption.runtime && ` · ${voteOption.runtime}분`}
-                        </p>
-                      </div>
-                      <div className='flex justify-end'>
-                        <Link
-                          className='btn btn-circle btn-sm btn-soft'
-                          href={`/movies/${voteOption.id}`}
-                        >
-                          <ChevronRight />
-                        </Link>
-                      </div>
-                    </div>
+                </div>
+                <div className='flex aspect-square flex-3 flex-col justify-between'>
+                  <div className='space-y-1'>
+                    <p className='text-lg font-semibold break-keep md:text-xl'>
+                      {voteOption.title}
+                    </p>
+                    <p className='text-sm break-keep text-gray-400'>
+                      {voteOption.release_date.slice(0, 4)} · {voteOption.genre_names.join(' / ')}
+                      {!!voteOption.runtime && ` · ${voteOption.runtime}분`}
+                    </p>
                   </div>
-                </label>
-              </li>
-            ))}
-            {!readOnly && (
-              <li className='col-span-full text-center'>
-                <button className='btn btn-primary' type='submit' disabled={!selected || isPending}>
-                  {isPending ? (
-                    <>
-                      <span className='loading loading-ring' />
-                    </>
-                  ) : (
-                    '투표 하기'
-                  )}
-                </button>
-              </li>
-            )}
-          </ul>
-        </form>
-      )}
-    </>
+                  <div className='flex justify-end'>
+                    <Link
+                      className='btn btn-circle btn-sm btn-soft'
+                      href={`/movies/${voteOption.id}`}
+                    >
+                      <ChevronRight />
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            </label>
+          </li>
+        ))}
+        {!readOnly && (
+          <li className='col-span-full text-center'>
+            <button className='btn btn-primary' type='submit' disabled={!selected || isPending}>
+              {isPending ? (
+                <>
+                  <span className='loading loading-ring' />
+                </>
+              ) : (
+                '투표 하기'
+              )}
+            </button>
+          </li>
+        )}
+      </ul>
+    </form>
   )
 }

--- a/src/app/board/actions.ts
+++ b/src/app/board/actions.ts
@@ -2,35 +2,25 @@
 
 import { auth } from '@/auth'
 import { COMMON_CODES } from '@/constants/messages/common'
-import { getMovie } from '@/lib/api/movie'
 import { participateVote } from '@/lib/api/vote'
-import { VoteResultWithMovie } from '@/types/api/vote'
 import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
 
 export const participateVoteAction = async (
-  state: { voteResults: VoteResultWithMovie[]; code: string },
+  state: { code: string } = { code: '' },
   formData: FormData
 ) => {
   const session = await auth()
-  if (!session) throw new Error('UNAUTHORIZED')
+  if (!session) redirect('/login')
 
   const tmdbId = formData.get('tmdbId') as string
 
   try {
-    const { results } = await participateVote(session.accessToken, {
+    await participateVote(session.accessToken, {
       tmdbId: Number(tmdbId),
     })
-    const tmdbIds = results.map((result) => result.tmdbId)
-    const movies = await Promise.all(tmdbIds.map((id) => getMovie(id.toString())))
-    const voteResults = movies.map((movie, index) => {
-      const result = results[index]
-      return {
-        ...movie,
-        ...result,
-      }
-    })
     revalidatePath('/board')
-    return { ...state, voteResults, code: COMMON_CODES.SUCCESS as string }
+    return { ...state }
   } catch (error) {
     const errorCode = (error as Error).message
     switch (errorCode) {
@@ -38,7 +28,7 @@ export const participateVoteAction = async (
         return { ...state, code: errorCode }
       default:
         console.error(error)
-        throw new Error('UNHANDLED_ERROR')
+        throw new Error(COMMON_CODES.UNHANDLED_ERROR)
     }
   }
 }

--- a/src/lib/api/vote.ts
+++ b/src/lib/api/vote.ts
@@ -1,17 +1,15 @@
 import {
-  CreateVoteResponse,
   GetVoteLatestResultResponse,
   GetVoteOptionsResponse,
   GetVoteParticipationStatusResponse,
   GetVoteResultResponse,
   ParticipateVoteRequest,
-  ParticipateVoteResponse,
 } from '@/types/api/vote'
 import { apiClient } from '../apiClient'
 
 // 투표 생성
-export async function createVote(token: string): Promise<CreateVoteResponse> {
-  return apiClient<CreateVoteResponse>(`/votes`, {
+export async function createVote(token: string): Promise<null> {
+  return apiClient<null>(`/votes`, {
     method: 'POST',
     withAuth: true,
     token,
@@ -19,11 +17,8 @@ export async function createVote(token: string): Promise<CreateVoteResponse> {
 }
 
 // 현재 진행중인 투표에 참여하기
-export async function participateVote(
-  token: string,
-  body: ParticipateVoteRequest
-): Promise<ParticipateVoteResponse> {
-  return apiClient<ParticipateVoteResponse, ParticipateVoteRequest>('/votes/participate', {
+export async function participateVote(token: string, body: ParticipateVoteRequest): Promise<null> {
+  return apiClient<null, ParticipateVoteRequest>('/votes/participate', {
     method: 'POST',
     body,
     withAuth: true,

--- a/src/types/api/vote.ts
+++ b/src/types/api/vote.ts
@@ -2,14 +2,11 @@ import { Movie } from './movie'
 
 // API 타입
 // 투표 생성
-export type CreateVoteResponse = VoteOptionsResponse
 
 // 현재 진행중인 투표에 참여하기
 export interface ParticipateVoteRequest {
   tmdbId: number
 }
-
-export type ParticipateVoteResponse = VoteResponse
 
 // 현재 진행중인 투표 결과 확인
 export type GetVoteResultResponse = VoteResponse


### PR DESCRIPTION
## 💡 Description
- `revalidatePath()` 도입으로 게시판 페이지에서의 투표 참여, 관리자 페이지에서의 투표 생성 후 클라이언트 측으로 직접 결과를 주입하던 로직 제거

## ✨ Changes
- 서버에서 성공 처리 하므로 클라이언트에서의 성공 처리 코드 삭제