### PR TITLE
[Feature] 리뷰 목록 페이지 로딩 UI 적용

### DIFF
--- a/src/app/admin/certifications/page.tsx
+++ b/src/app/admin/certifications/page.tsx
@@ -3,8 +3,6 @@ import { getCertifications } from '@/lib/api/certification'
 import { redirect } from 'next/navigation'
 import CertificationList from './CertificationList'
 import GoBackHeader from '@/components/layout/MobileHeader/GoBackHeader'
-import clsx from 'clsx'
-import Link from 'next/link'
 import {
   CERTIFICATION_STATUS,
   CertificationStatus,
@@ -12,6 +10,7 @@ import {
 } from '@/constants/certification'
 
 import { getIsSunday } from '@/lib/api/discussion'
+import SortButton from '@/components/ui/SortButton'
 
 export default async function AdminCertificationsPage({
   searchParams,
@@ -42,55 +41,39 @@ export default async function AdminCertificationsPage({
           <div className='btn btn-primary' tabIndex={0} role='button'>
             {getCertificationStatusBtnLabel(status)}
           </div>
-          <ul
+          <div
             className='menu dropdown-content bg-base-300 mt-2 space-y-2 rounded-3xl shadow-sm'
             tabIndex={0}
           >
-            <li>
-              <Link
-                className={clsx(
-                  'btn btn-primary w-[60px]',
-                  status === CERTIFICATION_STATUS.PENDING ? 'pointer-events-none' : 'btn-soft'
-                )}
-                href={`/admin/certifications?status=${CERTIFICATION_STATUS.PENDING}`}
-              >
-                {getCertificationStatusBtnLabel(CERTIFICATION_STATUS.PENDING)}
-              </Link>
-            </li>
-            <li>
-              <Link
-                className={clsx(
-                  'btn btn-primary',
-                  status === CERTIFICATION_STATUS.APPROVED ? 'pointer-events-none' : 'btn-soft'
-                )}
-                href={`/admin/certifications?status=${CERTIFICATION_STATUS.APPROVED}`}
-              >
-                {getCertificationStatusBtnLabel(CERTIFICATION_STATUS.APPROVED)}
-              </Link>
-            </li>
-            <li>
-              <Link
-                className={clsx(
-                  'btn btn-primary',
-                  status === CERTIFICATION_STATUS.REJECTED ? 'pointer-events-none' : 'btn-soft'
-                )}
-                href={`/admin/certifications?status=${CERTIFICATION_STATUS.REJECTED}`}
-              >
-                {getCertificationStatusBtnLabel(CERTIFICATION_STATUS.REJECTED)}
-              </Link>
-            </li>
-            <li>
-              <Link
-                className={clsx(
-                  'btn btn-primary',
-                  status === undefined ? 'pointer-events-none' : 'btn-soft'
-                )}
-                href='/admin/certifications'
-              >
-                {getCertificationStatusBtnLabel(undefined)}
-              </Link>
-            </li>
-          </ul>
+            <SortButton
+              pathPrefix='/admin/certifications'
+              queryKey='status'
+              targetValue={CERTIFICATION_STATUS.PENDING}
+              currentValue={status || ''}
+              label={getCertificationStatusBtnLabel(CERTIFICATION_STATUS.PENDING)}
+            />
+            <SortButton
+              pathPrefix='/admin/certifications'
+              queryKey='status'
+              targetValue={CERTIFICATION_STATUS.APPROVED}
+              currentValue={status || ''}
+              label={getCertificationStatusBtnLabel(CERTIFICATION_STATUS.APPROVED)}
+            />
+            <SortButton
+              pathPrefix='/admin/certifications'
+              queryKey='status'
+              targetValue={CERTIFICATION_STATUS.REJECTED}
+              currentValue={status || ''}
+              label={getCertificationStatusBtnLabel(CERTIFICATION_STATUS.REJECTED)}
+            />
+            <SortButton
+              pathPrefix='/admin/certifications'
+              queryKey='status'
+              targetValue={''}
+              currentValue={status || ''}
+              label={getCertificationStatusBtnLabel(undefined)}
+            />
+          </div>
         </div>
       </GoBackHeader>
       <div className='container-wrapper'>
@@ -99,42 +82,34 @@ export default async function AdminCertificationsPage({
             시청 인증 관리
           </h2>
           <div className='hidden space-x-3 md:block'>
-            <Link
-              className={clsx(
-                'btn btn-primary',
-                status === CERTIFICATION_STATUS.PENDING ? 'pointer-events-none' : 'btn-soft'
-              )}
-              href={`/admin/certifications?status=${CERTIFICATION_STATUS.PENDING}`}
-            >
-              {getCertificationStatusBtnLabel(CERTIFICATION_STATUS.PENDING)}
-            </Link>
-            <Link
-              className={clsx(
-                'btn btn-primary',
-                status === CERTIFICATION_STATUS.APPROVED ? 'pointer-events-none' : 'btn-soft'
-              )}
-              href={`/admin/certifications?status=${CERTIFICATION_STATUS.APPROVED}`}
-            >
-              {getCertificationStatusBtnLabel(CERTIFICATION_STATUS.APPROVED)}
-            </Link>
-            <Link
-              className={clsx(
-                'btn btn-primary',
-                status === CERTIFICATION_STATUS.REJECTED ? 'pointer-events-none' : 'btn-soft'
-              )}
-              href={`/admin/certifications?status=${CERTIFICATION_STATUS.REJECTED}`}
-            >
-              {getCertificationStatusBtnLabel(CERTIFICATION_STATUS.REJECTED)}
-            </Link>
-            <Link
-              className={clsx(
-                'btn btn-primary',
-                status === undefined ? 'pointer-events-none' : 'btn-soft'
-              )}
-              href='/admin/certifications'
-            >
-              {getCertificationStatusBtnLabel(undefined)}
-            </Link>
+            <SortButton
+              pathPrefix='/admin/certifications'
+              queryKey='status'
+              targetValue={CERTIFICATION_STATUS.PENDING}
+              currentValue={status || ''}
+              label={getCertificationStatusBtnLabel(CERTIFICATION_STATUS.PENDING)}
+            />
+            <SortButton
+              pathPrefix='/admin/certifications'
+              queryKey='status'
+              targetValue={CERTIFICATION_STATUS.APPROVED}
+              currentValue={status || ''}
+              label={getCertificationStatusBtnLabel(CERTIFICATION_STATUS.APPROVED)}
+            />
+            <SortButton
+              pathPrefix='/admin/certifications'
+              queryKey='status'
+              targetValue={CERTIFICATION_STATUS.REJECTED}
+              currentValue={status || ''}
+              label={getCertificationStatusBtnLabel(CERTIFICATION_STATUS.REJECTED)}
+            />
+            <SortButton
+              pathPrefix='/admin/certifications'
+              queryKey='status'
+              targetValue={''}
+              currentValue={status || ''}
+              label={getCertificationStatusBtnLabel(undefined)}
+            />
           </div>
         </div>
         {certifications.content.length === 0 ? (

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -1,47 +1,90 @@
-export const dynamic = 'force-dynamic'
-
 import { auth } from '@/auth'
-import OverlaidMovieHero from '@/components/ui/OverlaidMovieHero'
-import { getIsSunday, getThisWeekMovieId } from '@/lib/api/discussion'
-import { getMovie } from '@/lib/api/movie'
-import { Suspense } from 'react'
-import LatestReviewSection from './LatestReviewSection'
-import ReviewCarouselLoading from '../../components/ui/ReviewCarouselLoading'
-import BaseHeader from '@/components/layout/MobileHeader/BaseHeader'
-import VoteSection from './VoteSection'
-import MyReviewSection from './MyReviewSection'
+import GoBackHeader from '@/components/layout/MobileHeader/GoBackHeader'
+import ReviewList from '@/components/ui/ReviewList'
+import SortButton from '@/components/ui/SortButton'
+import { MOVIES_CODES } from '@/constants/messages/movie'
+import { getThisWeekMovieId } from '@/lib/api/discussion'
+import { getReviews } from '@/lib/api/review'
+import { ReviewSortField } from '@/types/api/common'
+import { notFound } from 'next/navigation'
 
-export default async function BoardPage() {
-  const [session, { isSunday }, { tmdbId }] = await Promise.all([
-    auth(),
-    getIsSunday(),
+export default async function BoardReviewsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ sort?: ReviewSortField }>
+}) {
+  const [{ tmdbId }, { sort = 'createdAt' }, session] = await Promise.all([
     getThisWeekMovieId(),
+    searchParams,
+    auth(),
   ])
+  const id = tmdbId.toString()
 
-  const movieId = tmdbId.toString()
-  const thisWeekMovie = await getMovie(movieId, !!session, session?.accessToken)
+  let reviews
+  try {
+    reviews = await getReviews(id, !!session, session?.accessToken, {
+      certifiedFilter: true,
+      page: 0,
+      size: 12,
+      sort: `${sort},desc`,
+    })
+  } catch (error) {
+    const errorCode = (error as Error).message
+    if (errorCode === MOVIES_CODES.MOVIE_NOT_FOUND) return notFound()
+    throw error
+  }
 
   return (
     <>
-      <BaseHeader />
-      <OverlaidMovieHero movie={thisWeekMovie} isSunday={isSunday} />
-      <div className='space-y-8'>
-        <VoteSection isSunday={isSunday} session={session} />
-        <MyReviewSection
-          isSunday={isSunday}
+      <GoBackHeader>
+        <h2 className='line-clamp-1 flex-1 text-xl font-semibold'>
+          {reviews.content[0]?.movieTitle}
+        </h2>
+        <div className='flex space-x-3'>
+          <SortButton
+            pathPrefix='/board/reviews'
+            targetValue='createdAt'
+            currentValue={sort}
+            label='최신'
+          />
+          <SortButton
+            pathPrefix='/board/reviews'
+            targetValue='likeCount'
+            currentValue={sort}
+            label='인기'
+          />
+        </div>
+      </GoBackHeader>
+      <div className='container-wrapper'>
+        <div className='flex items-center justify-between py-1'>
+          <h2 className='mt-4 mb-3 line-clamp-1 hidden text-xl font-semibold md:block'>
+            {reviews.content[0]?.movieTitle}
+          </h2>
+          <div className='hidden space-x-3 md:block'>
+            <SortButton
+              pathPrefix='/board/reviews'
+              targetValue='createdAt'
+              currentValue={sort}
+              label='최신'
+            />
+            <SortButton
+              pathPrefix='/board/reviews'
+              targetValue='likeCount'
+              currentValue={sort}
+              label='인기'
+            />
+          </div>
+        </div>
+
+        <ReviewList
           session={session}
-          movieId={movieId}
-          movieTitle={thisWeekMovie.title}
-          myReview={thisWeekMovie.myReview}
+          initialReviews={reviews.content}
+          initialLast={reviews.last}
+          withMovie={false}
+          movieId={id}
+          sort={sort}
+          certifiedFilter={true}
         />
-        {/* 최신 리뷰 유무로 제목 옆에 더보기 버튼 유무를 결정하기 때문에 이것만 다르게 컴포넌트화 함 */}
-        {!isSunday && (
-          <>
-            <Suspense fallback={<ReviewCarouselLoading />}>
-              <LatestReviewSection session={session} movieId={movieId} />
-            </Suspense>
-          </>
-        )}
       </div>
     </>
   )

--- a/src/app/movies/[id]/reviews/page.tsx
+++ b/src/app/movies/[id]/reviews/page.tsx
@@ -3,11 +3,10 @@ export const dynamic = 'force-dynamic'
 import { auth } from '@/auth'
 import GoBackHeader from '@/components/layout/MobileHeader/GoBackHeader'
 import ReviewList from '@/components/ui/ReviewList'
+import SortButton from '@/components/ui/SortButton'
 import { MOVIES_CODES } from '@/constants/messages/movie'
 import { getReviews } from '@/lib/api/review'
 import { ReviewSortField } from '@/types/api/common'
-import clsx from 'clsx'
-import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
 export default async function MoviesReviewsPage({
@@ -43,26 +42,18 @@ export default async function MoviesReviewsPage({
           {reviews.content[0]?.movieTitle}
         </h2>
         <div className='flex space-x-3'>
-          <Link
-            className={clsx(
-              'btn btn-primary',
-              sort === 'createdAt' ? 'pointer-events-none' : 'btn-soft'
-            )}
-            prefetch={false}
-            href={`/movies/${id}/reviews?sort=createdAt`}
-          >
-            최신
-          </Link>
-          <Link
-            className={clsx(
-              'btn btn-primary',
-              sort === 'likeCount' ? 'pointer-events-none' : 'btn-soft'
-            )}
-            prefetch={false}
-            href={`/movies/${id}/reviews?sort=likeCount`}
-          >
-            인기
-          </Link>
+          <SortButton
+            pathPrefix={`/movies/${id}/reviews`}
+            targetValue='createdAt'
+            currentValue={sort}
+            label='최신'
+          />
+          <SortButton
+            pathPrefix={`/movies/${id}/reviews`}
+            targetValue='likeCount'
+            currentValue={sort}
+            label='인기'
+          />
         </div>
       </GoBackHeader>
       <div className='container-wrapper'>
@@ -71,26 +62,18 @@ export default async function MoviesReviewsPage({
             {reviews.content[0]?.movieTitle}
           </h2>
           <div className='hidden space-x-3 md:block'>
-            <Link
-              className={clsx(
-                'btn btn-primary',
-                sort === 'createdAt' ? 'pointer-events-none' : 'btn-soft'
-              )}
-              prefetch={false}
-              href={`/movies/${id}/reviews?sort=createdAt`}
-            >
-              최신
-            </Link>
-            <Link
-              className={clsx(
-                'btn btn-primary',
-                sort === 'likeCount' ? 'pointer-events-none' : 'btn-soft'
-              )}
-              href={`/movies/${id}/reviews?sort=likeCount`}
-              prefetch={false}
-            >
-              인기
-            </Link>
+            <SortButton
+              pathPrefix={`/movies/${id}/reviews`}
+              targetValue='createdAt'
+              currentValue={sort}
+              label='최신'
+            />
+            <SortButton
+              pathPrefix={`/movies/${id}/reviews`}
+              targetValue='likeCount'
+              currentValue={sort}
+              label='인기'
+            />
           </div>
         </div>
 

--- a/src/app/profile/[id]/reviews/page.tsx
+++ b/src/app/profile/[id]/reviews/page.tsx
@@ -3,10 +3,9 @@ export const dynamic = 'force-dynamic'
 import { auth } from '@/auth'
 import GoBackHeader from '@/components/layout/MobileHeader/GoBackHeader'
 import ReviewList from '@/components/ui/ReviewList'
+import SortButton from '@/components/ui/SortButton'
 import { getUserReviews } from '@/lib/api/user'
 import { ReviewSortField } from '@/types/api/common'
-import clsx from 'clsx'
-import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 export default async function UserReviewsPage({
@@ -31,72 +30,48 @@ export default async function UserReviewsPage({
       <GoBackHeader>
         <h2 className='flex-1 text-xl font-semibold'>리뷰</h2>
         <div className='flex space-x-3'>
-          <Link
-            className={clsx(
-              'btn btn-primary',
-              sort === 'createdAt' ? 'pointer-events-none' : 'btn-soft'
-            )}
-            prefetch={false}
-            href={`/profile/${id}/reviews?sort=createdAt`}
-          >
-            최신
-          </Link>
-          <Link
-            className={clsx(
-              'btn btn-primary',
-              sort === 'likeCount' ? 'pointer-events-none' : 'btn-soft'
-            )}
-            prefetch={false}
-            href={`/profile/${id}/reviews?sort=likeCount`}
-          >
-            인기
-          </Link>
-          <Link
-            className={clsx(
-              'btn btn-primary',
-              sort === 'rating' ? 'pointer-events-none' : 'btn-soft'
-            )}
-            prefetch={false}
-            href={`/profile/${id}/reviews?sort=rating`}
-          >
-            별점
-          </Link>
+          <SortButton
+            pathPrefix={`/profile/${id}/reviews`}
+            targetValue='createdAt'
+            currentValue={sort}
+            label='최신'
+          />
+          <SortButton
+            pathPrefix={`/profile/${id}/reviews`}
+            targetValue='likeCount'
+            currentValue={sort}
+            label='인기'
+          />
+          <SortButton
+            pathPrefix={`/profile/${id}/reviews`}
+            targetValue='rating'
+            currentValue={sort}
+            label='별점'
+          />
         </div>
       </GoBackHeader>
       <div className='container-wrapper'>
         <div className='flex items-center justify-between py-1'>
           <h2 className='mt-4 mb-3 line-clamp-1 hidden text-xl font-semibold md:block'>리뷰</h2>
           <div className='hidden space-x-3 md:block'>
-            <Link
-              className={clsx(
-                'btn btn-primary',
-                sort === 'createdAt' ? 'pointer-events-none' : 'btn-soft'
-              )}
-              prefetch={false}
-              href={`/profile/${id}/reviews?sort=createdAt`}
-            >
-              최신
-            </Link>
-            <Link
-              className={clsx(
-                'btn btn-primary',
-                sort === 'likeCount' ? 'pointer-events-none' : 'btn-soft'
-              )}
-              href={`/profile/${id}/reviews?sort=likeCount`}
-              prefetch={false}
-            >
-              인기
-            </Link>
-            <Link
-              className={clsx(
-                'btn btn-primary',
-                sort === 'rating' ? 'pointer-events-none' : 'btn-soft'
-              )}
-              href={`/profile/${id}/reviews?sort=rating`}
-              prefetch={false}
-            >
-              별점
-            </Link>
+            <SortButton
+              pathPrefix={`/profile/${id}/reviews`}
+              targetValue='createdAt'
+              currentValue={sort}
+              label='최신'
+            />
+            <SortButton
+              pathPrefix={`/profile/${id}/reviews`}
+              targetValue='likeCount'
+              currentValue={sort}
+              label='인기'
+            />
+            <SortButton
+              pathPrefix={`/profile/${id}/reviews`}
+              targetValue='rating'
+              currentValue={sort}
+              label='별점'
+            />
           </div>
         </div>
 

--- a/src/components/ui/SortButton.tsx
+++ b/src/components/ui/SortButton.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import clsx from 'clsx'
+
+export default function SortButton({
+  pathPrefix,
+  queryKey = 'sort',
+  targetValue,
+  currentValue,
+  label,
+}: {
+  pathPrefix: string
+  queryKey?: string
+  targetValue: string
+  currentValue: string
+  label: string
+}) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+
+  const handleClick = () => {
+    startTransition(() => {
+      router.push(`${pathPrefix}?${queryKey}=${targetValue}`)
+    })
+  }
+
+  return (
+    <button
+      disabled={isPending}
+      onClick={handleClick}
+      className={clsx(
+        'btn btn-primary w-[58.2px]',
+        targetValue === currentValue ? 'pointer-events-none' : 'btn-soft'
+      )}
+    >
+      {isPending ? <span className='loading loading-ring' /> : label}
+    </button>
+  )
+}


### PR DESCRIPTION
## 💡 Description
- 리뷰 목록 페이지에서 필터 변경시 `searchParams`만 바뀌어, 로딩 중임에도 멈춘 것처럼 보이는 문제 해결

## ✨ Changes
- `Link`대신 `useRouter()`로 리다이렉트 처리하여 상태 감지 가능하도록 수정
- `useTransition()`으로 이동 중 상태를 감지하여 필터 버튼에 (`SortButton`) 로딩 UI 적용

## 📸 Screenshot
[Galaxy-S21-Ultra-deepdiview.vercel.app-_8v5t5hypyl_s1.webm](https://github.com/user-attachments/assets/10d0e900-950c-43c1-893a-2ef7368e13f6)