### PR TITLE
[Style] 페이지 전반 border-radius 및 UI 개선

### DIFF
--- a/src/app/admin/(admin)/CreateVoteSection.tsx
+++ b/src/app/admin/(admin)/CreateVoteSection.tsx
@@ -15,11 +15,11 @@ export default function CreateVoteSection({
     <section>
       <h3 className='mb-3 text-xl font-semibold'>투표 생성</h3>
       {isSunday ? (
-        <Suspense fallback={<div className='skeleton h-[72px] rounded-2xl' />}>
+        <Suspense fallback={<div className='skeleton h-[72px] rounded-3xl' />}>
           <CreateVoteWrapper session={session} />
         </Suspense>
       ) : (
-        <div className='bg-base-300 flex flex-col items-center gap-4 rounded-2xl p-4 md:flex-row md:justify-between md:gap-0'>
+        <div className='bg-base-300 flex flex-col items-center gap-4 rounded-3xl p-4 md:flex-row md:justify-between md:gap-0'>
           <p className='my-2'>투표는 일요일에만 생성할 수 있습니다.</p>
         </div>
       )}

--- a/src/app/admin/(admin)/CreateVoteWrapper.tsx
+++ b/src/app/admin/(admin)/CreateVoteWrapper.tsx
@@ -9,7 +9,7 @@ export default async function CreateVoteWrapper({ session }: { session: Session 
 
   if (tmdbIds.length === 0)
     return (
-      <div className='bg-base-300 flex flex-col items-center gap-4 rounded-2xl p-4 md:flex-row md:justify-between md:gap-0'>
+      <div className='bg-base-300 flex flex-col items-center gap-4 rounded-3xl p-4 md:flex-row md:justify-between md:gap-0'>
         <p>투표를 생성해 주세요.</p>
         <CreateVoteButton />
       </div>
@@ -17,7 +17,7 @@ export default async function CreateVoteWrapper({ session }: { session: Session 
 
   const movies = await Promise.all(tmdbIds.map((id) => getMovie(id.toString())))
   return (
-    <div className='bg-base-300 flex flex-col items-center gap-4 rounded-2xl p-4 md:flex-row md:justify-between md:gap-0'>
+    <div className='bg-base-300 flex flex-col items-center gap-4 rounded-3xl p-4 md:flex-row md:justify-between md:gap-0'>
       <div className='w-full'>
         <p className='mt-2 text-center md:text-start'>투표를 이미 생성했습니다.</p>
         <VoteCard voteOptions={movies} readOnly />

--- a/src/app/admin/(admin)/loading.tsx
+++ b/src/app/admin/(admin)/loading.tsx
@@ -3,11 +3,11 @@ export default function AdminLoading() {
     <div className='container-wrapper mt-2 space-y-6'>
       <section>
         <h3 className='mb-3 text-xl font-semibold'>시청 인증 관리</h3>
-        <div className='skeleton h-[72px] rounded-2xl' />
+        <div className='skeleton h-[72px] rounded-3xl' />
       </section>
       <section>
         <h3 className='mb-3 text-xl font-semibold'>투표 생성</h3>
-        <div className='skeleton h-[72px] rounded-2xl' />
+        <div className='skeleton h-[72px] rounded-3xl' />
       </section>
     </div>
   )

--- a/src/app/admin/(admin)/page.tsx
+++ b/src/app/admin/(admin)/page.tsx
@@ -16,7 +16,7 @@ export default async function AdminPage() {
     <div className='container-wrapper space-y-6 md:mt-2'>
       <section>
         <h3 className='mb-3 text-xl font-semibold'>시청 인증 관리</h3>
-        <div className='bg-base-300 flex flex-col items-center gap-4 rounded-2xl p-4 md:flex-row md:justify-between md:gap-0'>
+        <div className='bg-base-300 flex flex-col items-center gap-4 rounded-3xl p-4 md:flex-row md:justify-between md:gap-0'>
           {isSunday ? (
             <p className='my-2 break-keep'>일요일에는 시청 인증이 없습니다.</p>
           ) : (

--- a/src/app/board/LatestReviewSection.tsx
+++ b/src/app/board/LatestReviewSection.tsx
@@ -29,7 +29,7 @@ export default async function LatestReviewSection({
         )}
       </div>
       {reviews.length === 0 ? (
-        <div className='bg-base-300 rounded-2xl px-4 py-6 text-center md:text-start'>
+        <div className='bg-base-300 rounded-3xl px-4 py-6 text-center md:text-start'>
           <p>아직 리뷰가 없습니다.</p>
         </div>
       ) : (

--- a/src/app/board/MyReviewSection.tsx
+++ b/src/app/board/MyReviewSection.tsx
@@ -28,13 +28,13 @@ export default function MyReviewSection({
               {myReview ? (
                 <ReviewItem review={myReview} withMovie={false} />
               ) : (
-                <Suspense fallback={<div className='skeleton h-18 rounded-2xl' />}>
+                <Suspense fallback={<div className='skeleton h-18 rounded-3xl' />}>
                   <MyReviewWrapper session={session} movieId={movieId} movieTitle={movieTitle} />
                 </Suspense>
               )}
             </>
           ) : (
-            <div className='bg-base-300 flex flex-col items-center gap-4 rounded-2xl p-4 md:flex-row md:justify-between md:gap-0'>
+            <div className='bg-base-300 flex flex-col items-center gap-4 rounded-3xl p-4 md:flex-row md:justify-between md:gap-0'>
               <p className='text-center break-keep'>
                 <span className='font-bold'>DeepDiview</span> 회원이 되셔서 이 영화에 대한 생각을
                 공유해주세요!

--- a/src/app/board/MyReviewWrapper.tsx
+++ b/src/app/board/MyReviewWrapper.tsx
@@ -14,7 +14,7 @@ export default async function MyReviewWrapper({
   const { status: certificationStatus } = await getCertification(session?.accessToken)
 
   return (
-    <div className='bg-base-300 flex flex-col items-center gap-4 rounded-2xl p-4 md:flex-row md:justify-between md:gap-0'>
+    <div className='bg-base-300 flex flex-col items-center gap-4 rounded-3xl p-4 md:flex-row md:justify-between md:gap-0'>
       <p className='text-center break-keep'>
         이 주의 영화에 대한 <span className='font-bold'>{session.user?.nickname}</span> 님의 생각이
         궁금해요!

--- a/src/app/board/VoteCard.tsx
+++ b/src/app/board/VoteCard.tsx
@@ -43,7 +43,7 @@ export default function VoteCard({
                 onChange={() => setSelected(voteOption.id)}
                 disabled={readOnly}
               />
-              <div className='bg-base-100 peer-checked:ring-primary flex gap-4 rounded-lg p-4 peer-checked:ring-2'>
+              <div className='bg-base-100 peer-checked:ring-primary flex gap-4 rounded-3xl p-4 peer-checked:ring-2'>
                 <div className='relative aspect-2/3 flex-2 overflow-hidden rounded-lg'>
                   <Image
                     src={`https://image.tmdb.org/t/p/w500${voteOption.poster_path}`}

--- a/src/app/board/VoteResultCard.tsx
+++ b/src/app/board/VoteResultCard.tsx
@@ -13,7 +13,7 @@ export default function VoteResultCard({
 }) {
   const totalVotes = voteResults.reduce((sum: number, result) => sum + result.voteCount, 0)
   return (
-    <div className='bg-base-300 rounded-2xl p-4'>
+    <div className='bg-base-300 rounded-3xl p-4'>
       {withTitle && <p className='mb-4'>일요일엔 게시판이 쉽니다!</p>}
       <ul className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'>
         {voteResults.map((voteResult) => (
@@ -21,7 +21,7 @@ export default function VoteResultCard({
             <Link href={`/movies/${voteResult.id}`}>
               <div
                 className={clsx(
-                  'bg-base-100 flex gap-4 rounded-lg p-4',
+                  'bg-base-100 flex gap-4 rounded-3xl p-4',
                   voteResult.voted && 'ring-primary ring-2'
                 )}
               >

--- a/src/app/board/VoteSection.tsx
+++ b/src/app/board/VoteSection.tsx
@@ -32,13 +32,13 @@ export default function VoteSection({
               session ? (
                 // 로그인 O
                 // 투표 또는 진행중인 투표 결과 (접기 가능)
-                <Suspense fallback={<div className='skeleton h-18 rounded-2xl' />}>
+                <Suspense fallback={<div className='skeleton h-18 rounded-3xl' />}>
                   <VoteWrapper session={session} />
                 </Suspense>
               ) : (
                 // 로그인 X
                 // 로그인 안내
-                <div className='bg-base-300 flex flex-col items-center gap-4 rounded-2xl p-4 md:flex-row md:justify-between md:gap-0'>
+                <div className='bg-base-300 flex flex-col items-center gap-4 rounded-3xl p-4 md:flex-row md:justify-between md:gap-0'>
                   <p className='text-center break-keep'>
                     <span className='font-bold'>DeepDiview</span> 의 회원이 되셔서 다음주 영화에
                     투표해 주세요!

--- a/src/app/board/VoteToggle.tsx
+++ b/src/app/board/VoteToggle.tsx
@@ -43,7 +43,7 @@ export default function VoteToggle({
   }, [isOpen])
 
   return (
-    <div className='bg-base-300 overflow-hidden rounded-2xl px-4 py-6'>
+    <div className='bg-base-300 overflow-hidden rounded-3xl px-4 py-6'>
       <button
         className='flex w-full justify-between'
         onClick={() => {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,8 +7,8 @@
   default: false;
   prefersdark: true;
   color-scheme: 'dark';
-  --color-base-100: oklch(20% 0 0);
-  --color-base-200: oklch(10% 0 0);
+  --color-base-100: oklch(21% 0 0);
+  --color-base-200: oklch(10.5% 0 0);
   --color-base-300: oklch(0% 0 0);
   --color-base-content: oklch(97.807% 0.029 256.847);
   --color-primary: oklch(0.5814 0.2349 27.99);
@@ -95,11 +95,11 @@
     }
   }
   .profile-btn {
-    @apply btn text-base-100 bg-base-content absolute flex h-7 w-7 items-center justify-center rounded-full border-0 p-1;
+    @apply btn text-base-100 bg-base-content disabled:text-base-content absolute flex h-7 w-7 items-center justify-center rounded-full border-0 p-1;
   }
 
   .user-input {
-    @apply input bg-base-300 md:bg-base-100 focus-within:bg-primary/10 w-full rounded-full border-none p-0 px-4 shadow-none outline-none focus-within:shadow-none focus-within:outline-none;
+    @apply input bg-base-300 md:bg-base-100 focus-within:bg-primary/15 w-full rounded-full border-none p-0 px-4 shadow-none outline-none focus-within:shadow-none focus-within:outline-none;
   }
 
   .auth-form {

--- a/src/app/movies/[id]/LatestReviewSection.tsx
+++ b/src/app/movies/[id]/LatestReviewSection.tsx
@@ -24,7 +24,7 @@ export default function LatestReviewSection({
         )}
       </div>
       {latestReviews.length === 0 ? (
-        <div className='bg-base-300 rounded-2xl px-4 py-6 text-center md:text-start'>
+        <div className='bg-base-300 rounded-3xl px-4 py-6 text-center md:text-start'>
           <p>아직 리뷰가 없습니다.</p>
         </div>
       ) : (

--- a/src/app/movies/[id]/MyReviewSection.tsx
+++ b/src/app/movies/[id]/MyReviewSection.tsx
@@ -33,7 +33,7 @@ export default function MyReviewSection({
             <ReviewItem review={myReview} withMovie={false} />
           ) : (
             // 작성한 리뷰가 없는 경우
-            <div className='bg-base-300 flex flex-col items-center gap-4 rounded-2xl p-4 md:flex-row md:justify-between md:gap-0'>
+            <div className='bg-base-300 flex flex-col items-center gap-4 rounded-3xl p-4 md:flex-row md:justify-between md:gap-0'>
               {isThisWeekMovie && !isSunday ? (
                 // 인증된 리뷰가 작성 가능한 경우 (이주의 영화이면서 일요일이 아닌 경우)
                 <>
@@ -97,7 +97,7 @@ export default function MyReviewSection({
       ) : (
         // 로그인 안한 경우
         // 로그인 안내
-        <div className='bg-base-300 flex flex-col items-center gap-4 rounded-2xl p-4 md:flex-row md:justify-between md:gap-0'>
+        <div className='bg-base-300 flex flex-col items-center gap-4 rounded-3xl p-4 md:flex-row md:justify-between md:gap-0'>
           <p className='text-center break-keep'>
             <span className='font-bold'>DeepDiview</span> 회원이 되셔서 이 영화에 대한 생각을
             공유해주세요!

--- a/src/app/profile/[id]/(profile)/IntroForm.tsx
+++ b/src/app/profile/[id]/(profile)/IntroForm.tsx
@@ -94,7 +94,7 @@ export default function IntroForm({
 
   if (!isCurrentUser)
     return (
-      <div className='bg-base-100 w-full rounded-2xl p-4'>
+      <div className='bg-base-100 w-full rounded-3xl p-4'>
         <p className={clsx('text-center', !intro && 'text-gray-500')}>
           {intro || '한 줄 소개가 없습니다.'}
         </p>
@@ -105,7 +105,7 @@ export default function IntroForm({
     <div className='w-full'>
       {isEditing ? (
         <form action={formAction}>
-          <div className='bg-base-100 relative rounded-2xl p-4'>
+          <div className='bg-base-100 relative rounded-3xl p-4'>
             <input
               {...register('oneLineIntro')}
               className='w-full border-none text-center outline-none'
@@ -141,7 +141,7 @@ export default function IntroForm({
           )}
         </form>
       ) : (
-        <div className='bg-base-100 relative w-full rounded-2xl p-4'>
+        <div className='bg-base-100 relative w-full rounded-3xl p-4'>
           <p className={clsx('text-center', !intro && 'text-gray-500')}>
             {intro || '한 줄 소개가 없습니다.'}
           </p>

--- a/src/app/profile/[id]/(profile)/ProfileWrapper.tsx
+++ b/src/app/profile/[id]/(profile)/ProfileWrapper.tsx
@@ -29,7 +29,7 @@ export default function ProfileWrapper({
       {/* 프로필 정보 섹션, 별점 그래프 섹션 flex container */}
       <div className='w-full space-y-4 md:flex md:items-center md:justify-center md:gap-4 md:space-y-0'>
         {/* 프로필 정보 섹션 */}
-        <section className='bg-base-300 relative flex h-[380px] flex-col justify-between gap-4 rounded-2xl p-4 md:flex-1 lg:flex-2'>
+        <section className='bg-base-300 relative flex h-[380px] flex-col justify-between gap-4 rounded-3xl p-4 md:flex-1 lg:flex-2'>
           {isCurrentUser && (
             <button
               className='absolute top-4 right-4 text-gray-500'
@@ -99,7 +99,7 @@ export default function ProfileWrapper({
         </section>
 
         {/* 별점 분석 */}
-        <section className='bg-base-300 flex h-[250px] flex-col gap-4 rounded-2xl p-4 md:h-[380px] md:flex-1'>
+        <section className='bg-base-300 flex h-[250px] flex-col gap-4 rounded-3xl p-4 md:h-[380px] md:flex-1'>
           <RatingBarChart
             ratingDistribution={profile.ratingStats.ratingDistribution}
             ratingAverage={profile.ratingStats.ratingAverage}

--- a/src/app/profile/[id]/(profile)/SettingsSection.tsx
+++ b/src/app/profile/[id]/(profile)/SettingsSection.tsx
@@ -5,7 +5,7 @@ import LogoutButton from './LogoutButton'
 export default function SettingsSection({ isAdmin }: { isAdmin: boolean }) {
   return (
     <section className='mt-4 w-full'>
-      <div className='bg-base-300 rounded-2xl p-4'>
+      <div className='bg-base-300 rounded-3xl p-4'>
         <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'>
           <Link className='btn btn-primary btn-soft w-full' href='/profile/update-password'>
             비밀번호 변경

--- a/src/app/profile/[id]/(profile)/loading.tsx
+++ b/src/app/profile/[id]/(profile)/loading.tsx
@@ -6,8 +6,8 @@ export default function loading() {
   return (
     <div className='container-wrapper flex flex-col md:flex-1 md:items-center md:justify-center'>
       <div className='w-full space-y-4 md:flex md:items-center md:justify-center md:gap-4 md:space-y-0'>
-        <div className='skeleton h-[380px] rounded-2xl md:flex-1 lg:flex-2' />
-        <div className='skeleton h-[250px] rounded-2xl md:h-[380px] md:flex-1' />
+        <div className='skeleton h-[380px] rounded-3xl md:flex-1 lg:flex-2' />
+        <div className='skeleton h-[250px] rounded-3xl md:h-[380px] md:flex-1' />
       </div>
     </div>
   )

--- a/src/app/profile/[id]/comments/ReviewWithCommentWrapper.tsx
+++ b/src/app/profile/[id]/comments/ReviewWithCommentWrapper.tsx
@@ -12,7 +12,7 @@ export default function ReviewWithCommentWrapper({
 }) {
   return (
     <Link href={`/reviews/${comment.reviewId}`}>
-      <div className='space-y-2 rounded-2xl bg-black/3.5 p-4 dark:bg-white/5'>
+      <div className='space-y-2 rounded-3xl bg-black/4 p-4 dark:bg-white/4'>
         <p className='text-gray-400'>{getRelativeTime(comment.createdAt)}</p>
         <p className='line-clamp-1 break-all'>{comment.content}</p>
         {children}

--- a/src/app/search/SearchMovieItem.tsx
+++ b/src/app/search/SearchMovieItem.tsx
@@ -13,7 +13,7 @@ export default function SearchMovieItem({ movie }: { movie: Movie }) {
             src={`https://image.tmdb.org/t/p/w500${movie.poster_path}`}
             alt='영화 포스터'
             fill
-            className={clsx('rounded-md', !movie.available && 'grayscale')}
+            className={clsx('rounded-lg', !movie.available && 'grayscale')}
           />
         </div>
         <div className='line-clamp-3 flex w-full flex-col justify-between'>

--- a/src/components/form/ReviewForm.tsx
+++ b/src/components/form/ReviewForm.tsx
@@ -75,7 +75,7 @@ export default function ReviewForm({
     <form action={formAction} className='flex flex-1 flex-col'>
       <GoBackHeader>
         <div className='flex flex-1 items-center gap-2'>
-          <h2 className='line-clamp-1 rounded-xl text-xl font-semibold'>{movieTitle}</h2>
+          <h2 className='line-clamp-1 text-xl font-semibold'>{movieTitle}</h2>
           {certified && <CertifiedBadge />}
         </div>
         <button className='btn btn-primary' type='submit' disabled={isPending || !isValid}>
@@ -91,7 +91,7 @@ export default function ReviewForm({
           {isPending ? <span className='loading loading-ring' /> : <>{isEdit ? '수정' : '작성'}</>}
         </button>
       </div>
-      <div className='bg-base-300 flex flex-1 flex-col rounded-2xl p-5 md:p-7'>
+      <div className='bg-base-300 flex flex-1 flex-col rounded-3xl p-5 md:p-7'>
         <div className='mb-5 md:mb-7'>
           <Rating rating={initialValue?.rating} register={register('rating')} />
         </div>

--- a/src/components/form/SearchForm.tsx
+++ b/src/components/form/SearchForm.tsx
@@ -26,7 +26,7 @@ export default function SearchForm() {
 
   return (
     <form onSubmit={handleSubmit} className='w-full'>
-      <label className='input focus-within:border-primary focus-within:bg-primary/10 w-full border-0 bg-gray-400/10 focus-within:outline-none'>
+      <label className='input focus-within:border-primary focus-within:bg-primary/15 w-full border-0 bg-gray-400/10 focus-within:outline-none'>
         <Search className='h-[1em] opacity-50' />
         <input
           className='placeholder-gray-400'

--- a/src/components/ui/AuthFormWrapper.tsx
+++ b/src/components/ui/AuthFormWrapper.tsx
@@ -14,7 +14,7 @@ export default function AuthFormWrapper({
 }) {
   return (
     <div className='container-wrapper flex-1 md:flex md:items-center md:justify-center'>
-      <div className='md:bg-base-300 md:flex md:flex-col md:gap-2 md:rounded-2xl md:p-8'>
+      <div className='md:bg-base-300 md:flex md:flex-col md:gap-2 md:rounded-3xl md:p-8'>
         <h2 className='hidden text-center text-xl font-semibold md:mb-4 md:block'>{title}</h2>
         {currentStep && <RegisterProgressBar currentStep={currentStep} />}
         {description && <p className='mt-6 mb-1.5 font-semibold'>{description}</p>}

--- a/src/components/ui/CertificationItemWrapper.tsx
+++ b/src/components/ui/CertificationItemWrapper.tsx
@@ -23,7 +23,7 @@ export default function CertificationItemWrapper({
   return (
     <div
       className={clsx(
-        'space-y-2 rounded-2xl p-4',
+        'space-y-2 rounded-3xl p-4',
         certification.status === CERTIFICATION_STATUS.NONE && 'bg-base-300',
         certification.status === CERTIFICATION_STATUS.APPROVED && 'bg-success/15',
         certification.status === CERTIFICATION_STATUS.PENDING && 'bg-warning/15',
@@ -75,7 +75,7 @@ export default function CertificationItemWrapper({
           </div>
         </>
       )}
-      <div className='bg-base-100 relative flex h-80 w-full items-center justify-center overflow-hidden rounded-2xl'>
+      <div className='bg-base-100 relative flex h-80 w-full items-center justify-center overflow-hidden rounded-3xl'>
         {certification.certificationDetails?.certificationUrl || croppedImage ? (
           <InnerImageZoom
             src={

--- a/src/components/ui/LikeButton.tsx
+++ b/src/components/ui/LikeButton.tsx
@@ -80,7 +80,7 @@ export default function LikeButton({
         <div className='flex gap-1'>
           <button
             className={clsx(
-              'cursor-pointer active:animate-ping',
+              'active:animate-jump cursor-pointer',
               !optimisticState.likedByUser && 'animate-pulse'
             )}
             type='submit'

--- a/src/components/ui/MovieCarouselLoading.tsx
+++ b/src/components/ui/MovieCarouselLoading.tsx
@@ -4,7 +4,7 @@ export default function MovieCarouselLoading() {
       {[...Array(5)].map((_, i) => (
         <div
           key={i}
-          className='skeleton aspect-2/3 w-[calc((100%-16px)/3)] flex-shrink-0 snap-start rounded-xl md:w-[calc((100%-48px)/4)] lg:w-[calc((100%-64px)/5)]'
+          className='skeleton aspect-2/3 w-[calc((100%-16px)/3)] flex-shrink-0 snap-start rounded-lg md:w-[calc((100%-48px)/4)] lg:w-[calc((100%-64px)/5)]'
         />
       ))}
     </div>

--- a/src/components/ui/OverlaidMovieHeroLoading.tsx
+++ b/src/components/ui/OverlaidMovieHeroLoading.tsx
@@ -7,7 +7,7 @@ export default function OverlaidMovieHeroLoading({ isSunday }: { isSunday: boole
         <div className='flex flex-col items-center gap-4 md:flex-row md:items-start md:gap-0 lg:px-6'>
           {/* 포스터 */}
           <div className='w-full flex-2 px-16 md:pr-6 md:pl-0 lg:pr-12 lg:pl-0'>
-            <div className='skeleton relative aspect-2/3 w-full' />
+            <div className='skeleton relative aspect-2/3 w-full rounded-lg' />
           </div>
 
           {/* 정보 */}

--- a/src/components/ui/ReviewItem.tsx
+++ b/src/components/ui/ReviewItem.tsx
@@ -53,7 +53,7 @@ export default function ReviewItem({
   const content = (
     <div
       className={clsx(
-        'bg-base-300 rounded-2xl p-4',
+        'bg-base-300 rounded-3xl p-4',
         withMovie ? 'space-y-3' : 'flex flex-col gap-3',
         withMovie === false && isDetail === false && 'h-64'
       )}
@@ -83,7 +83,7 @@ export default function ReviewItem({
             <Link href={`/movies/${review.tmdbId}`}>
               <div className='flex flex-col items-center gap-3 py-2 md:float-left md:mr-6 md:py-0'>
                 <Image
-                  className='rounded-2xl'
+                  className='rounded-lg'
                   src={`https://image.tmdb.org/t/p/w500${review.posterPath}`}
                   alt={`${review.movieTitle} 포스터`}
                   width={200}


### PR DESCRIPTION
## 💡 Description
- 페이지 전반의 `border-radius` 및 UI 개선

## ✨ Changes
- 카드/섹션/아이템 형 UI 요소에 `rounded-3xl` 적용
- 영화 포스터에 `rounded-lg` 적용
- 좋아요 버튼 클릭 시 `jump` 애니메이션 적용
- 다크 테마에서 `base` 색상 간 대비 증가
- 검색 폼의 `background-color` 조정