### PR TITLE
[Fix] 댓글 낙관적 UI 중복 표시 버그 수정

### DIFF
--- a/src/app/reviews/[id]/CommentItem.tsx
+++ b/src/app/reviews/[id]/CommentItem.tsx
@@ -43,7 +43,7 @@ export default function CommentItem({
   const isMyRecentCreatedComment =
     isMyComment &&
     comment.optimisticStatus === undefined &&
-    Date.now() - new Date(comment.createdAt).getTime() < 3000
+    Date.now() - new Date(comment.createdAt).getTime() < 2000
 
   // 삭제 중
   // CommentForm 작성, 내가 쓴 다른 댓글의 수정, 삭제 비활성화

--- a/src/app/reviews/[id]/CommentSection.tsx
+++ b/src/app/reviews/[id]/CommentSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useOptimistic, useRef, useState } from 'react'
+import { startTransition, useEffect, useOptimistic, useRef, useState } from 'react'
 import CommentForm from './CommentForm'
 import CommentList from './CommentList'
 import { getComments } from '@/lib/api/comment'
@@ -51,15 +51,19 @@ export default function CommentSection({
   // 댓글 작성
   // Comments에 성공 응답으로 받은 댓글  추가
   const handleCreateSuccess = (createdComment: Comment) => {
-    setComments((prev) => [createdComment, ...prev])
+    startTransition(() => {
+      setComments((prev) => [createdComment, ...prev])
+    })
   }
 
   // 댓글 수정
   // Comments에 성공 응답으로 받은 댓글로 교체
   const handleEditSuccess = (updatedComment: Comment) => {
-    setComments((prev) =>
-      prev.map((comment) => (comment.id === updatedComment.id ? updatedComment : comment))
-    )
+    startTransition(() => {
+      setComments((prev) =>
+        prev.map((comment) => (comment.id === updatedComment.id ? updatedComment : comment))
+      )
+    })
   }
 
   // 댓글 삭제


### PR DESCRIPTION
## 💡 Description
- 간헐적으로 댓글 작성 시 낙관적으로 추가된 댓글과 서버 응답으로 받은 댓글이 잠시 중복 표시되는 현상 개선

## ✨ Changes
- 댓글 작성 서버 액션 성공 후 댓글 목록  업데이트를 startTransition으로 처리하여 중복 표시 방지