### PR TITLE
[Fix] 게시판 리뷰 목록 페이지 접근 차단 버그 수정

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -44,7 +44,7 @@ function isMatch(pathname: string, urls: string[]) {
 const authRoutes = ['/login', '/register']
 
 const privateRoutes = [
-  '/board/*path',
+  '/board/create',
   '/movies/:path/reviews/create',
   '/notifications',
   '/profile/*path',


### PR DESCRIPTION
## 💡 Description
- 로그인 없이 접근 가능한 페이지인 게시판 리뷰 목록 페이지(/board/reviews)를 미들웨어에서 라우트 보호 처리하여 접근 차단되는 버그 수정

## ✨ Changes
- 미들웨어의 `privateRoutes`의  `/board/*path` 을 `/board/create`로 수정하여 인증된 리뷰 작성 페이지만 보호 처리