### PR TITLE
[Feature] 시청 인증 관리 페이지 로딩 UI 추가

### DIFF
--- a/src/app/admin/certifications/CertificationListWrapper.tsx
+++ b/src/app/admin/certifications/CertificationListWrapper.tsx
@@ -1,0 +1,35 @@
+import { CertificationStatus } from '@/constants/certification'
+import { getCertifications } from '@/lib/api/certification'
+import { Session } from 'next-auth'
+import CertificationList from './CertificationList'
+
+export default async function CertificationListWrapper({
+  session,
+  status,
+}: {
+  session: Session
+  status?: CertificationStatus
+}) {
+  const certifications = await getCertifications(session.accessToken, {
+    status,
+    page: 0,
+    size: 12,
+  })
+
+  return (
+    <>
+      {certifications.content.length === 0 ? (
+        <>시청 인증이 없습니다.</>
+      ) : (
+        <CertificationList
+          session={session}
+          initialCertifications={certifications.content}
+          initialLast={!certifications.hasNext}
+          initialNextCreatedAt={certifications.nextCreatedAt}
+          initialNextId={certifications.nextId}
+          status={status}
+        />
+      )}
+    </>
+  )
+}

--- a/src/app/admin/certifications/SortButtons.tsx
+++ b/src/app/admin/certifications/SortButtons.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import SortButton from '@/components/ui/SortButton'
+import {
+  CERTIFICATION_STATUS,
+  CertificationStatus,
+  getCertificationStatusBtnLabel,
+} from '@/constants/certification'
+import clsx from 'clsx'
+import { useEffect, useState } from 'react'
+
+export default function SortButtons({ status }: { status?: CertificationStatus }) {
+  const [isPending, setIsPending] = useState(false)
+
+  useEffect(() => {
+    setIsPending(false)
+  }, [status])
+
+  return (
+    <div className='dropdown dropdown-center'>
+      <div
+        className={clsx('btn btn-primary', isPending && 'btn-disabled text-primary')}
+        tabIndex={0}
+        role='button'
+      >
+        {isPending ? (
+          <span className='loading loading-ring' />
+        ) : (
+          getCertificationStatusBtnLabel(status)
+        )}
+      </div>
+      <div
+        className='menu dropdown-content bg-base-300 mt-2 space-y-2 rounded-3xl shadow-sm'
+        tabIndex={0}
+      >
+        <SortButton
+          pathPrefix='/admin/certifications'
+          queryKey='status'
+          targetValue={CERTIFICATION_STATUS.PENDING}
+          currentValue={status || ''}
+          label={getCertificationStatusBtnLabel(CERTIFICATION_STATUS.PENDING)}
+          setIsPending={setIsPending}
+        />
+        <SortButton
+          pathPrefix='/admin/certifications'
+          queryKey='status'
+          targetValue={CERTIFICATION_STATUS.APPROVED}
+          currentValue={status || ''}
+          label={getCertificationStatusBtnLabel(CERTIFICATION_STATUS.APPROVED)}
+          setIsPending={setIsPending}
+        />
+        <SortButton
+          pathPrefix='/admin/certifications'
+          queryKey='status'
+          targetValue={CERTIFICATION_STATUS.REJECTED}
+          currentValue={status || ''}
+          label={getCertificationStatusBtnLabel(CERTIFICATION_STATUS.REJECTED)}
+          setIsPending={setIsPending}
+        />
+        <SortButton
+          pathPrefix='/admin/certifications'
+          queryKey='status'
+          targetValue={''}
+          currentValue={status || ''}
+          label={getCertificationStatusBtnLabel(undefined)}
+          setIsPending={setIsPending}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/certifications/page.tsx
+++ b/src/app/admin/certifications/page.tsx
@@ -1,7 +1,5 @@
 import { auth } from '@/auth'
-import { getCertifications } from '@/lib/api/certification'
 import { redirect } from 'next/navigation'
-import CertificationList from './CertificationList'
 import GoBackHeader from '@/components/layout/MobileHeader/GoBackHeader'
 import {
   CERTIFICATION_STATUS,
@@ -11,6 +9,10 @@ import {
 
 import { getIsSunday } from '@/lib/api/discussion'
 import SortButton from '@/components/ui/SortButton'
+import CertificationListWrapper from './CertificationListWrapper'
+import { Suspense } from 'react'
+import ReviewListLoading from '@/components/ui/ReviewListLoading'
+import SortButtons from './SortButtons'
 
 export const metadata = {
   title: '시청 인증 관리',
@@ -25,60 +27,17 @@ export default async function AdminCertificationsPage({
   if (!session) redirect('/login')
 
   const { isSunday } = await getIsSunday()
-  if (isSunday) redirect(`/admin`)
+  if (isSunday) redirect('/admin')
 
   if (session.user?.role !== 'ADMIN') redirect('/')
 
   const { status } = await searchParams
 
-  const certifications = await getCertifications(session.accessToken, {
-    status,
-    page: 0,
-    size: 12,
-  })
-
   return (
     <>
       <GoBackHeader>
         <h2 className='line-clamp-1 flex-1 text-xl font-semibold'>시청 인증 관리</h2>
-        <div className='dropdown dropdown-center'>
-          <div className='btn btn-primary' tabIndex={0} role='button'>
-            {getCertificationStatusBtnLabel(status)}
-          </div>
-          <div
-            className='menu dropdown-content bg-base-300 mt-2 space-y-2 rounded-3xl shadow-sm'
-            tabIndex={0}
-          >
-            <SortButton
-              pathPrefix='/admin/certifications'
-              queryKey='status'
-              targetValue={CERTIFICATION_STATUS.PENDING}
-              currentValue={status || ''}
-              label={getCertificationStatusBtnLabel(CERTIFICATION_STATUS.PENDING)}
-            />
-            <SortButton
-              pathPrefix='/admin/certifications'
-              queryKey='status'
-              targetValue={CERTIFICATION_STATUS.APPROVED}
-              currentValue={status || ''}
-              label={getCertificationStatusBtnLabel(CERTIFICATION_STATUS.APPROVED)}
-            />
-            <SortButton
-              pathPrefix='/admin/certifications'
-              queryKey='status'
-              targetValue={CERTIFICATION_STATUS.REJECTED}
-              currentValue={status || ''}
-              label={getCertificationStatusBtnLabel(CERTIFICATION_STATUS.REJECTED)}
-            />
-            <SortButton
-              pathPrefix='/admin/certifications'
-              queryKey='status'
-              targetValue={''}
-              currentValue={status || ''}
-              label={getCertificationStatusBtnLabel(undefined)}
-            />
-          </div>
-        </div>
+        <SortButtons status={status} />
       </GoBackHeader>
       <div className='container-wrapper'>
         <div className='flex items-center justify-between py-1'>
@@ -116,18 +75,9 @@ export default async function AdminCertificationsPage({
             />
           </div>
         </div>
-        {certifications.content.length === 0 ? (
-          <>시청 인증이 없습니다.</>
-        ) : (
-          <CertificationList
-            session={session}
-            initialCertifications={certifications.content}
-            initialLast={!certifications.hasNext}
-            initialNextCreatedAt={certifications.nextCreatedAt}
-            initialNextId={certifications.nextId}
-            status={status}
-          />
-        )}
+        <Suspense fallback={<ReviewListLoading isCertification />}>
+          <CertificationListWrapper session={session} status={status} />
+        </Suspense>
       </div>
     </>
   )

--- a/src/components/ui/ReviewListLoading.tsx
+++ b/src/components/ui/ReviewListLoading.tsx
@@ -5,11 +5,13 @@ export default function ReviewListLoading({
   withMovie = false,
   withoutProfile = false,
   withComment = false,
+  isCertification = false,
 }: {
   withoutMovie?: boolean
   withMovie?: boolean
   withoutProfile?: boolean
   withComment?: boolean
+  isCertification?: boolean
 }) {
   return (
     <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'>
@@ -21,7 +23,8 @@ export default function ReviewListLoading({
             withoutMovie && 'h-64',
             withMovie && 'aspect-5/4',
             withoutProfile && 'aspect-9/7',
-            withComment && 'aspect-8/7'
+            withComment && 'aspect-8/7',
+            isCertification && 'h-[412px]'
           )}
         />
       ))}

--- a/src/components/ui/SortButton.tsx
+++ b/src/components/ui/SortButton.tsx
@@ -10,17 +10,20 @@ export default function SortButton({
   targetValue,
   currentValue,
   label,
+  setIsPending,
 }: {
   pathPrefix: string
   queryKey?: string
   targetValue: string
   currentValue: string
   label: string
+  setIsPending?: (state: boolean) => void
 }) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
 
   const handleClick = () => {
+    setIsPending?.(true)
     startTransition(() => {
       const separator = pathPrefix.includes('?') ? '&' : '?'
       router.push(`${pathPrefix}${separator}${queryKey}=${targetValue}`)


### PR DESCRIPTION
## 💡 Description
- 배포 환경에서 시청 인증 관리 페이지 진입 시 로딩 상태가 없어 멈춘 것처럼 보이는 UX 문제 개선
- 시청 인증 관리 페이지에서 필터 변경시 `searchParams`만 바뀌어, 로딩 중임에도 멈춘 것처럼 보이는 문제 해결


## ✨ Changes
- 시청 인증 관리 페이지에 `CertificationListWrapper` 추가
- `CertificationListWrapper`에 `Suspense` 적용하여 로딩 상태 처리
- `SortButton`으로 필터 변경시 로딩 UI 적용
- 모바일의 드롭 다운 버튼에도 로딩 UI 적용을 위해 `SortButton`을 확장하고 `SortButtons` 추가

## 📸 Screenshot
[Galaxy-S21-Ultra-deepdiview.vercel.app-qnh_2pwz266zgl.webm](https://github.com/user-attachments/assets/11dab0ad-900e-4546-8ce5-f2638a7ad7c8)