### PR TITLE
[Feature] 로그인, 리뷰 삭제 후 리다이렉트 흐름 개선

### DIFF
--- a/src/app/(auth)/login/LoginForm.tsx
+++ b/src/app/(auth)/login/LoginForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useActionState, useEffect } from 'react'
+import { useActionState, useEffect, useRef } from 'react'
 import { signInWithCredentials } from './actions'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -10,9 +10,26 @@ import Link from 'next/link'
 import AuthFormInput from '@/components/form/AuthFormInput'
 import AuthSubmitButton from '@/components/form/AuthSubmitButton'
 import { USER_CODES, USER_MESSAGES } from '@/constants/messages/users'
+import { useSearchParams } from 'next/navigation'
+import toast from 'react-hot-toast'
 
 export default function LoginForm() {
-  const [state, formAction, isPending] = useActionState(signInWithCredentials, { code: '' })
+  const searchParams = useSearchParams()
+  const from = searchParams.get('from')
+  const toastShownRef = useRef(false)
+
+  useEffect(() => {
+    if (toastShownRef.current) return
+    if (!from) return
+    if (from.startsWith('/profile')) {
+      toast.error('프로필은 로그인 후 볼 수 있습니다.')
+      toastShownRef.current = true
+    }
+  }, [from])
+
+  const [state, formAction, isPending] = useActionState(signInWithCredentials.bind(null, from), {
+    code: '',
+  })
 
   const {
     register,

--- a/src/app/(auth)/login/actions.ts
+++ b/src/app/(auth)/login/actions.ts
@@ -6,7 +6,11 @@ import { USER_CODES } from '@/constants/messages/users'
 import { loginSchema } from '@/schemas/auth/loginSchema'
 import { redirect } from 'next/navigation'
 
-export const signInWithCredentials = async (state: { code: string }, formData: FormData) => {
+export const signInWithCredentials = async (
+  from: string | null,
+  state: { code: string },
+  formData: FormData
+) => {
   const validatedFields = loginSchema.safeParse({
     email: formData.get('email'),
     password: formData.get('password'),
@@ -41,5 +45,13 @@ export const signInWithCredentials = async (state: { code: string }, formData: F
         throw new Error(COMMON_CODES.UNHANDLED_ERROR)
     }
   }
-  redirect('/') // 로그인 성공시 홈으로 리디렉션
+
+  const isSafeFrom =
+    from &&
+    from.startsWith('/') &&
+    !from.startsWith('//') &&
+    !from.startsWith('/login') &&
+    !from.startsWith('/register')
+
+  redirect(isSafeFrom ? from : '/')
 }

--- a/src/app/board/MyReviewSection.tsx
+++ b/src/app/board/MyReviewSection.tsx
@@ -26,7 +26,7 @@ export default function MyReviewSection({
           {session ? (
             <>
               {myReview ? (
-                <ReviewItem review={myReview} withMovie={false} />
+                <ReviewItem from={`/board`} review={myReview} withMovie={false} />
               ) : (
                 <Suspense fallback={<div className='skeleton h-18 rounded-3xl' />}>
                   <MyReviewWrapper session={session} movieId={movieId} movieTitle={movieTitle} />
@@ -39,7 +39,7 @@ export default function MyReviewSection({
                 <span className='font-bold'>DeepDiview</span> 회원이 되셔서 이 영화에 대한 생각을
                 공유해주세요!
               </p>
-              <Link className='btn btn-primary' href='/login'>
+              <Link className='btn btn-primary' href='/login?from=/board'>
                 로그인하고 리뷰 작성하기
               </Link>
             </div>

--- a/src/app/board/VoteSection.tsx
+++ b/src/app/board/VoteSection.tsx
@@ -43,7 +43,7 @@ export default function VoteSection({
                     <span className='font-bold'>DeepDiview</span> 의 회원이 되셔서 다음주 영화에
                     투표해 주세요!
                   </p>
-                  <Link className='btn btn-primary' href='/login'>
+                  <Link className='btn btn-primary' href='/login?from=/board'>
                     로그인하고 투표하기
                   </Link>
                 </div>

--- a/src/app/board/create/actions.ts
+++ b/src/app/board/create/actions.ts
@@ -9,7 +9,7 @@ import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 
 export const createBoardReviewAction = async (
-  state: { code: string; resReviewId: string },
+  state: { code: string; resReviewId: string; isEdit: boolean },
   formData: FormData
 ) => {
   const session = await auth()

--- a/src/app/movies/[id]/MyReviewSection.tsx
+++ b/src/app/movies/[id]/MyReviewSection.tsx
@@ -30,7 +30,7 @@ export default function MyReviewSection({
           {myReview ? (
             // 작성한 리뷰가 있는 경우
             // ReviewItem으로 작성한 리뷰 출력
-            <ReviewItem review={myReview} withMovie={false} />
+            <ReviewItem from={`/movies/${movieId}`} review={myReview} withMovie={false} />
           ) : (
             // 작성한 리뷰가 없는 경우
             <div className='bg-base-300 flex flex-col items-center gap-4 rounded-3xl p-4 md:flex-row md:justify-between md:gap-0'>
@@ -102,7 +102,7 @@ export default function MyReviewSection({
             <span className='font-bold'>DeepDiview</span> 회원이 되셔서 이 영화에 대한 생각을
             공유해주세요!
           </p>
-          <Link className='btn btn-primary' href='/login'>
+          <Link className='btn btn-primary' href={`/login?from=/movies/${movieId}`}>
             로그인하고 리뷰 작성하기
           </Link>
         </div>

--- a/src/app/movies/[id]/reviews/create/actions.ts
+++ b/src/app/movies/[id]/reviews/create/actions.ts
@@ -10,7 +10,7 @@ import { redirect } from 'next/navigation'
 
 export const createReviewAction = async (
   tmdbId: string,
-  state: { code: string; resReviewId: string },
+  state: { code: string; resReviewId: string; isEdit: boolean },
   formData: FormData
 ) => {
   const session = await auth()

--- a/src/app/profile/[id]/(profile)/page.tsx
+++ b/src/app/profile/[id]/(profile)/page.tsx
@@ -10,9 +10,9 @@ import { USER_CODES } from '@/constants/messages/users'
 
 export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
   const session = await auth()
-  if (!session || !session.user) redirect('/login')
-
   const { id } = await params
+  if (!session || !session.user) redirect(`/login?from=/profile/${id}`)
+
   const { userId } = session.user
   const isCurrentUser = userId === Number(id)
 
@@ -39,9 +39,10 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
 
 export default async function ProfilePage({ params }: { params: Promise<{ id: string }> }) {
   const session = await auth()
-  if (!session || !session.user) redirect('/login')
-
   const [{ id }, { isSunday }] = await Promise.all([params, getIsSunday()])
+
+  if (!session || !session.user) redirect(`/login?from=/profile/${id}`)
+
   const { userId, role } = session.user
   const isCurrentUser = userId === Number(id)
 

--- a/src/app/reviews/[id]/CommentForm.tsx
+++ b/src/app/reviews/[id]/CommentForm.tsx
@@ -195,7 +195,7 @@ export default function CommentForm({
                   )}
                 </>
               ) : (
-                <Link className='btn btn-primary' href='/login'>
+                <Link className='btn btn-primary' href={`/login?from=/reviews/${reviewId}`}>
                   로그인
                 </Link>
               )}

--- a/src/app/reviews/[id]/DeleteReviewButton.tsx
+++ b/src/app/reviews/[id]/DeleteReviewButton.tsx
@@ -2,11 +2,16 @@
 
 import { useActionState, useEffect } from 'react'
 import { deleteReviewAction } from './actions'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { COMMON_CODES, COMMON_MESSAGES } from '@/constants/messages/common'
 import toast from 'react-hot-toast'
 
 export default function DeleteReviewButton({ reviewId }: { reviewId: string }) {
+  const searchParams = useSearchParams()
+  const rawFrom = searchParams.get('from') ?? ''
+  const from = decodeURIComponent(rawFrom)
+  const isSafeFrom = from.startsWith('/') && !from.startsWith('//')
+
   const [state, formAction, isPending] = useActionState<{
     code: string
   }>(deleteReviewAction.bind(null, reviewId), {
@@ -16,15 +21,19 @@ export default function DeleteReviewButton({ reviewId }: { reviewId: string }) {
 
   useEffect(() => {
     if (state.code === '') return
-    // TODO: 삭제 후 알맞은 곳으로 리디렉션하기
-    // 게시판, 영화 상세 정보 페이지, 내가 쓴 리뷰 목록 등 여러 곳에서 리뷰에 접근 할 수 있기 때문에
-    // searchParams에 from을 넣는 것도 고려
-    if (state.code === COMMON_CODES.SUCCESS) router.replace('/')
+
+    if (state.code === COMMON_CODES.SUCCESS) {
+      if (isSafeFrom) {
+        router.replace(from)
+      } else {
+        router.back()
+      }
+    }
 
     if (state.code === COMMON_CODES.NETWORK_ERROR) {
       toast.error(COMMON_MESSAGES.NETWORK_ERROR!)
     }
-  }, [router, state])
+  }, [from, isSafeFrom, router, state])
 
   return (
     <>

--- a/src/app/reviews/[id]/actions.ts
+++ b/src/app/reviews/[id]/actions.ts
@@ -6,6 +6,7 @@ import { REVIEW_CODES } from '@/constants/messages/review'
 import { createComment, deleteComment, updateComment } from '@/lib/api/comment'
 import { deleteReview } from '@/lib/api/review'
 import { commentSchema } from '@/schemas/review/commentSchema'
+import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 
 export const createCommentAction = async (reviewId: string, content: string) => {
@@ -24,6 +25,7 @@ export const createCommentAction = async (reviewId: string, content: string) => 
     const comment = await createComment(reviewId, session.accessToken, {
       content: validatedContent,
     })
+    revalidatePath(`/profile/${session.user?.userId}/comments`)
     return { code: COMMON_CODES.SUCCESS, comment }
   } catch (error) {
     const errorCode = (error as Error).message
@@ -57,6 +59,7 @@ export const updateCommentAction = async (reviewId: string, commentId: string, c
       { content: validatedContent },
       session.accessToken
     )
+    revalidatePath(`/profile/${session.user?.userId}/comments`)
     return { code: COMMON_CODES.SUCCESS, comment: comment }
   } catch (error) {
     const errorCode = (error as Error).message
@@ -81,6 +84,7 @@ export const deleteCommentAction = async (
 
   try {
     await deleteComment(reviewId, commentId, session.accessToken)
+    revalidatePath(`/profile/${session.user?.userId}/comments`)
     return { ...state, code: COMMON_CODES.SUCCESS as string, commentId }
   } catch (error) {
     const errorCode = (error as Error).message

--- a/src/app/reviews/[id]/edit/actions.ts
+++ b/src/app/reviews/[id]/edit/actions.ts
@@ -4,11 +4,12 @@ import { auth } from '@/auth'
 import { COMMON_CODES } from '@/constants/messages/common'
 import { updateReview } from '@/lib/api/review'
 import { updateReviewServerSchema } from '@/schemas/review/updateReviewSchema'
+import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 
 export const updateReviewAction = async (
   reviewId: string,
-  state: { code: string; resReviewId: string },
+  state: { code: string; resReviewId: string; isEdit: boolean },
   formData: FormData
 ) => {
   const session = await auth()
@@ -32,7 +33,13 @@ export const updateReviewAction = async (
       content,
       rating,
     })
-    return { ...state, code: COMMON_CODES.SUCCESS, resReviewId: resReviewId.toString() }
+    revalidatePath(`/reviews/${reviewId}`)
+    return {
+      ...state,
+      code: COMMON_CODES.SUCCESS,
+      resReviewId: resReviewId.toString(),
+      isEdit: true,
+    }
   } catch (error) {
     const errorCode = (error as Error).message
     switch (errorCode) {

--- a/src/components/form/ReviewForm.tsx
+++ b/src/components/form/ReviewForm.tsx
@@ -19,9 +19,9 @@ export default function ReviewForm({
   certified,
 }: {
   action: (
-    state: { code: string; resReviewId: string },
+    state: { code: string; resReviewId: string; isEdit: boolean },
     formData: FormData
-  ) => Promise<{ code: string; resReviewId: string }>
+  ) => Promise<{ code: string; resReviewId: string; isEdit: boolean }>
   movieTitle: string
   initialValue?: { title: string; content: string; rating: number }
   certified: boolean
@@ -30,6 +30,7 @@ export default function ReviewForm({
   const [state, formAction, isPending] = useActionState(action, {
     code: '',
     resReviewId: '',
+    isEdit: false,
   })
   const router = useRouter()
 
@@ -56,7 +57,11 @@ export default function ReviewForm({
     if (state.code === '') return
 
     if (state.code === COMMON_CODES.SUCCESS) {
-      return router.replace(`/reviews/${state.resReviewId}`)
+      if (isEdit) {
+        return router.back()
+      } else {
+        return router.replace(`/reviews/${state.resReviewId}`)
+      }
     }
 
     if (state.code === COMMON_CODES.NETWORK_ERROR) {
@@ -69,7 +74,7 @@ export default function ReviewForm({
       toast.error(REVIEW_MESSAGES.ALREADY_COMMITTED_REVIEW)
       return router.push('/')
     }
-  }, [reset, router, state, watch])
+  }, [isEdit, reset, router, state, watch])
 
   return (
     <form action={formAction} className='flex flex-1 flex-col'>

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -12,8 +12,12 @@ import { useUserStore } from '@/stores/useUserStore'
 
 export default function BottomNav({ session }: { session: Session | null }) {
   const profileImageUrl = useUserStore((state) => state.profileImageUrl)
+
   const pathname = usePathname()
   const searchParams = useSearchParams()
+  const fullPath =
+    searchParams.toString().length > 0 ? `${pathname}?${searchParams.toString()}` : pathname
+
   const isFromNav = searchParams.get('from') === 'nav'
   const { isKeyboardVisible } = useMobileKeyboard()
 
@@ -71,7 +75,7 @@ export default function BottomNav({ session }: { session: Session | null }) {
           </>
         ) : (
           <Link
-            href='/login'
+            href={`/login?from=${encodeURIComponent(fullPath)}`}
             className={clsx({
               'dock-active text-primary': pathname.startsWith('/login'),
             })}

--- a/src/components/layout/TopNav.tsx
+++ b/src/components/layout/TopNav.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import SearchForm from '@/components/form/SearchForm'
 import { useEffect, useState } from 'react'
 import clsx from 'clsx'
-import { usePathname } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import Image from 'next/image'
 import NotificationBadge from '../ui/NotificationBadge'
 import { Session } from 'next-auth'
@@ -13,7 +13,11 @@ import { useUserStore } from '@/stores/useUserStore'
 export default function TopNav({ session }: { session: Session | null }) {
   const profileImageUrl = useUserStore((state) => state.profileImageUrl)
   const [scrolled, setScrolled] = useState(false)
+
   const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const fullPath =
+    searchParams.toString().length > 0 ? `${pathname}?${searchParams.toString()}` : pathname
 
   const overlaidPaths = ['/', '/board']
   const overlaidDynamicPaths = /^\/(movies)\/[^/]+$/.test(pathname)
@@ -82,7 +86,7 @@ export default function TopNav({ session }: { session: Session | null }) {
             ) : (
               <Link
                 className='btn btn-ghost hover:text-primary p-0 text-base hover:border-transparent hover:bg-transparent hover:shadow-none'
-                href='/login'
+                href={`/login?from=${encodeURIComponent(fullPath)}`}
               >
                 로그인
               </Link>

--- a/src/components/ui/ReviewCarousel.tsx
+++ b/src/components/ui/ReviewCarousel.tsx
@@ -4,6 +4,7 @@ import { Review } from '@/types/api/common'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useRef, useState, useEffect } from 'react'
 import ReviewItem from './ReviewItem'
+import { usePathname, useSearchParams } from 'next/navigation'
 
 export default function ReviewCarousel({
   reviews,
@@ -12,6 +13,11 @@ export default function ReviewCarousel({
   reviews: Review[]
   withMovie?: boolean
 }) {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const fullPath =
+    searchParams.toString().length > 0 ? `${pathname}?${searchParams.toString()}` : pathname
+
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const [isAtStart, setIsAtStart] = useState(true)
   const [isAtEnd, setIsAtEnd] = useState(false)
@@ -62,7 +68,7 @@ export default function ReviewCarousel({
             className='w-full flex-shrink-0 snap-start md:w-[calc((100%-8px)/2)] lg:w-[calc((100%-24px)/3)]'
             key={review.reviewId}
           >
-            <ReviewItem review={review} withMovie={withMovie} />
+            <ReviewItem from={fullPath} review={review} withMovie={withMovie} />
           </div>
         ))}
       </div>

--- a/src/components/ui/ReviewItem.tsx
+++ b/src/components/ui/ReviewItem.tsx
@@ -11,12 +11,14 @@ import ReviewWithCommentWrapper from '@/app/profile/[id]/comments/ReviewWithComm
 import { ReviewWithComment } from '@/types/api/user'
 
 export default function ReviewItem({
+  from,
   review,
   withMovie = true,
   withComment = false,
   isDetail = false,
   isUserReviewsPage = false,
 }: {
+  from?: string
   review: Review | ReviewWithComment
   withMovie?: boolean
   withComment?: boolean
@@ -138,5 +140,9 @@ export default function ReviewItem({
   // 리뷰 상세 페이지
   if (isDetail) return <>{content}</>
 
-  return <Link href={`/reviews/${review.reviewId}`}>{content}</Link>
+  return (
+    <Link href={`/reviews/${review.reviewId}?from=${encodeURIComponent(from || '')}`}>
+      {content}
+    </Link>
+  )
 }

--- a/src/components/ui/ReviewList.tsx
+++ b/src/components/ui/ReviewList.tsx
@@ -7,6 +7,7 @@ import type { Review, ReviewSortField } from '@/types/api/common'
 import { Session } from 'next-auth'
 import { getUserComments, getUserReviews } from '@/lib/api/user'
 import { ReviewWithComment } from '@/types/api/user'
+import { usePathname, useSearchParams } from 'next/navigation'
 
 export default function ReviewList({
   session,
@@ -31,6 +32,11 @@ export default function ReviewList({
   sort?: ReviewSortField
   certifiedFilter?: boolean
 }) {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const fullPath =
+    searchParams.toString().length > 0 ? `${pathname}?${searchParams.toString()}` : pathname
+
   const [reviews, setReviews] = useState<Review[] | ReviewWithComment[]>([])
   const [page, setPage] = useState(1)
   const [hasMore, setHasMore] = useState<boolean>()
@@ -130,6 +136,7 @@ export default function ReviewList({
         {reviews.map((review) => (
           <ReviewItem
             key={withComment && 'comment' in review ? review.comment.id : review.reviewId}
+            from={fullPath}
             review={review}
             withMovie={withMovie}
             withComment={withComment}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -47,7 +47,10 @@ const privateRoutes = [
   '/board/create',
   '/movies/:path/reviews/create',
   '/notifications',
-  '/profile/*path',
+  '/profile/:path/*path',
+  '/profile/delete-account',
+  '/profile/submit-certification',
+  '/profile/update-password',
   '/reviews/:path/edit',
 ]
 


### PR DESCRIPTION
## 💡 Description
- 로그인, 리뷰 삭제 후 리다이렉트 흐름 개선

## ✨ Changes
- 로그인 페이지 진입 시 직전 경로를 `from` 쿼리 파라미터로 포함
- 로그인 성공 후 `from` 경로로 리다이렉트
- 비로그인 상태로 프로필 페이지 진입 시 로그인 페이지에서 안내 토스트 메시지 표시
- 리뷰 상세 페이지 진입 시 `from` 쿼리 파라미터 포함
- 리뷰 삭제 성공 후 `from` 경로로 리다이렉트
- 리뷰 삭제 후 `revalidatePath()`로 삭제된 리뷰가 다시 보이지 않도록 처리