### PR TITLE
[Fix] 별점을 마지막에 입력할 경우 유효성 검사가 작동하지 않던 버그 수정

### DIFF
--- a/src/components/ui/Rating.tsx
+++ b/src/components/ui/Rating.tsx
@@ -44,7 +44,10 @@ export default function Rating({
               name='rating'
               value={number}
               defaultChecked={number === rating}
-              onChange={() => setSelected(number)}
+              onChange={(e) => {
+                register?.onChange(e)
+                setSelected(number)
+              }}
               required
             />
           )


### PR DESCRIPTION
## 💡 Description
- 리뷰 작성 폼에서 별점(rating)을 마지막에 선택할 경우 유효성 검사가 즉시 트리거되지 않아 작성 버튼이 비활성화되는 문제 수정

## ✨ Changes
- `Rating` input에서 `register?.onChange(e)`를 호출하여 `react-hook-form`의 유효성 검사가 정상적으로 작동하도록 처리